### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Description
+<!-- Provide a clear and concise description of the bug -->
+
+## Steps to Reproduce
+<!-- Steps to reproduce the behavior -->
+1.
+2.
+3.
+4.
+
+## Expected Behavior
+<!-- Describe what you expected to happen -->
+
+## Actual Behavior
+<!-- Describe what actually happened -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+
+- OS:
+- Browser/Application:
+- Version:
+
+## Additional Information
+<!-- Add any other context about the problem here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Description
+<!-- Provide a clear and concise description of the feature you'd like -->
+
+## Reason
+<!-- Explain why this feature is needed and what problem it solves -->
+
+## Proposed Implementation
+<!-- If you have an idea of how to implement this feature, please describe it here -->
+
+## Alternatives Considered
+<!-- Describe any alternative solutions or features you've considered -->
+
+## Additional Information
+<!-- Add any other context or screenshots about the feature request here -->

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,19 @@
+---
+name: Other Question
+about: Questions or inquiries not related to bugs or feature requests
+title: "[QUESTION] "
+labels: question
+assignees: ''
+---
+
+## Description
+<!-- Freely describe your question or inquiry -->
+
+## Context
+<!-- Provide any relevant context or background information -->
+
+## What I've Tried
+<!-- Describe what you've already tried or researched -->
+
+## Additional Information
+<!-- Add any other context or screenshots about your question here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What
+<!-- Describe what changes this PR introduces -->
+
+## Why
+<!-- Explain why these changes are necessary or beneficial -->
+
+## Related
+<!-- Reference any related issues or PRs using #issue_number or user/repo#issue_number format -->
+
+## Additional Notes
+<!-- Add any other context about the PR here -->
+
+## Checklist
+
+- [ ] I have performed a self-review of my code
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I have updated the documentation accordingly


### PR DESCRIPTION
## What
Add GitHub Issue templates (bug report, feature request, other) and PR template.

## Why
To improve project collaboration and standardize issue reporting.

## Related
N/A

## Additional Notes
Templates are created in English as requested.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly