### PR TITLE
:factory: Add poetry venv settings for vscode

### DIFF
--- a/summarizer/.vscode/settings.json
+++ b/summarizer/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": ".venv/bin/python"
+}

--- a/summarizer/poetry.toml
+++ b/summarizer/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/summarizer/pyproject.toml
+++ b/summarizer/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "テキスト要約API"
 authors = ["Geshi Team"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"

--- a/summarizer/src/main.py
+++ b/summarizer/src/main.py
@@ -1,8 +1,9 @@
+from typing import List, Optional
+
+import uvicorn
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from typing import List, Optional
-import uvicorn
 
 app = FastAPI(
     title="Summarizer API",

--- a/transcriber/.vscode/settings.json
+++ b/transcriber/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": ".venv/bin/python"
+}

--- a/transcriber/poetry.toml
+++ b/transcriber/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true


### PR DESCRIPTION
## What

主に vscode 向けに python の設定を変更

## Why

- transcriber と summarizer の python interpreter を vscode がうまく見つけられてない
- `~/.cache/` にそれぞれの virtualenv ができてるが transciber/.vscode/settings.json にフルパスを書いてしまうと移植性がなくなる
- poetry での venv をプロジェクトローカルになるようにして，defaultInterpreterPath も相対で指定する

## Related

n/a

## Additional Notes

n/a

## Checklist

- [x] I have performed a self-review of my code
- ~[x] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
