### PR TITLE
Refine source tree interactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: db-up db-down dev-up dev-down dev-reset \
 	db-schema-dry-run db-schema-apply db-schema-apply-with-drop \
-	e2e-db-up e2e-db-down e2e-db-reset e2e-db-schema-apply test-e2e
+	db-data-migrate \
+	e2e-db-up e2e-db-down e2e-db-reset e2e-db-schema-apply \
+	test-e2e
 
 PSQLDEF_VERSION ?= 3.11.1
 PSQLDEF_IMAGE := sqldef/psqldef:$(PSQLDEF_VERSION)
@@ -12,6 +14,7 @@ DB_NAME ?= geshi
 DB_PORT ?= 55432
 DEV_COMPOSE := docker compose -f compose.yaml
 TEST_COMPOSE := docker compose -f test/compose.test.yaml
+DATA_MIGRATION ?=
 
 db-up:
 	$(DEV_COMPOSE) up -d postgres
@@ -64,6 +67,11 @@ db-schema-apply-with-drop:
 		--enable-drop \
 		--config-inline $(PSQLDEF_CONFIG_INLINE) \
 		--apply < db/schema.sql 2>&1 | tee $(DB_SCHEMA_APPLY_WITH_DROP_LOG)
+
+db-data-migrate:
+	@test -n "$(DATA_MIGRATION)" || (echo "DATA_MIGRATION is required" >&2; exit 1)
+	@COMPOSE_FILE_PATH=compose.yaml DB_NAME=$(DB_NAME) DB_USER=geshi \
+		sh scripts/run-data-migration.sh "$(DATA_MIGRATION)"
 
 e2e-db-up:
 	$(TEST_COMPOSE) up -d postgres

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,16 +1,20 @@
 import { Hono } from "hono";
 
 import type { AppDependencies } from "./deps.js";
+import { createCollectionRoutes } from "./routes/api/v1/collections.js";
 import { createContentRoutes } from "./routes/api/v1/contents.js";
 import { createJobRoutes } from "./routes/api/v1/jobs.js";
 import { createSettingRoutes } from "./routes/api/v1/settings.js";
 import { createSourceRoutes } from "./routes/api/v1/sources.js";
+import { createSubscriptionRoutes } from "./routes/api/v1/subscriptions.js";
 import { createMediaAssetRoutes } from "./routes/media/assets.js";
 
 export function createApp(dependencies: AppDependencies): Hono {
   const app = new Hono();
 
   app.route("/api/v1/sources", createSourceRoutes(dependencies));
+  app.route("/api/v1/collections", createCollectionRoutes(dependencies));
+  app.route("/api/v1/subscriptions", createSubscriptionRoutes(dependencies));
   app.route("/api/v1/settings", createSettingRoutes(dependencies));
   app.route("/api/v1/contents", createContentRoutes(dependencies));
   app.route("/api/v1/jobs", createJobRoutes(dependencies));

--- a/backend/src/db/source-repository.ts
+++ b/backend/src/db/source-repository.ts
@@ -7,11 +7,15 @@ import type { JsonValue, SourceCollectorSourceKind } from "../plugins/types.js";
 import type { SourcePeriodicCrawlSettings } from "../service/periodic-crawl-settings.js";
 import { defaultSourcePeriodicCrawlSettings } from "../service/periodic-crawl-settings.js";
 import type {
+  CollectionTable,
   CollectorSettingSnapshotTable,
   CollectorSettingTable,
   GeshiDatabase,
   SourceSnapshotTable,
   SourceTable,
+  SubscriptionEventTable,
+  SubscriptionTable,
+  UserTable,
 } from "./types.js";
 
 export type CreateSourceInput = {
@@ -23,9 +27,28 @@ export type CreateSourceInput = {
   pluginSlug: string;
   slug: string;
   snapshotId: string;
+  subscriptionEventId: string;
+  subscriptionId: string;
   title?: string | null;
   url: string;
   urlHash: string;
+  userSlug: string;
+};
+
+export type CreateCollectionInput = {
+  id: string;
+  parentCollectionId?: string | null;
+  position: number;
+  title: string;
+  userSlug: string;
+};
+
+export type UpdateCollectionInput = {
+  collectionId: string;
+  parentCollectionId?: string | null;
+  position?: number;
+  title?: string;
+  userSlug: string;
 };
 
 export type ObserveSourceTarget = {
@@ -42,6 +65,7 @@ export type ObserveSourceTarget = {
 };
 
 export type SourceListItem = {
+  collectionId: string | null;
   collectorSettingsVersion: number | null;
   periodicCrawlEnabled: boolean;
   periodicCrawlIntervalMinutes: number;
@@ -51,10 +75,21 @@ export type SourceListItem = {
   kind: SourceCollectorSourceKind;
   recordedAt: Date | null;
   slug: string;
+  subscriptionId: string;
+  subscriptionPosition: number;
   title: string | null;
   url: string;
   urlHash: string;
   version: number | null;
+};
+
+export type SourceCollectionListItem = {
+  createdAt: Date;
+  id: string;
+  parentCollectionId: string | null;
+  position: number;
+  sourceCount: number;
+  title: string;
 };
 
 export type PeriodicCrawlSourceTarget = ObserveSourceTarget;
@@ -93,49 +128,94 @@ export class SourceRepository {
     try {
       return ok(
         await this.database.transaction().execute(async (transaction) => {
+          const user = await ensureUserBySlug(transaction, input.userSlug);
+          const existingSource = await transaction
+            .selectFrom("sources")
+            .selectAll()
+            .where("url_hash", "=", input.urlHash)
+            .executeTakeFirst();
+
+          const sourceId = existingSource?.id ?? input.id;
+
+          if (existingSource === undefined) {
+            await transaction
+              .insertInto("sources")
+              .values(toSourceInsert(input))
+              .executeTakeFirstOrThrow();
+
+            await transaction
+              .insertInto("source_snapshots")
+              .values(toSourceSnapshotInsert(input))
+              .executeTakeFirstOrThrow();
+
+            await transaction
+              .insertInto("collector_settings")
+              .values(toCollectorSettingInsert(input))
+              .executeTakeFirstOrThrow();
+
+            await transaction
+              .insertInto("collector_setting_snapshots")
+              .values(toCollectorSettingSnapshotInsert(input))
+              .executeTakeFirstOrThrow();
+          }
+
           await transaction
-            .insertInto("sources")
-            .values(toSourceInsert(input))
+            .insertInto("subscriptions")
+            .values(toSubscriptionInsert(input, user.id, sourceId))
             .executeTakeFirstOrThrow();
 
           await transaction
-            .insertInto("source_snapshots")
-            .values(toSourceSnapshotInsert(input))
-            .executeTakeFirstOrThrow();
-
-          await transaction
-            .insertInto("collector_settings")
-            .values(toCollectorSettingInsert(input))
-            .executeTakeFirstOrThrow();
-
-          await transaction
-            .insertInto("collector_setting_snapshots")
-            .values(toCollectorSettingSnapshotInsert(input))
+            .insertInto("subscription_events")
+            .values(toSubscriptionEventInsert(input, user.id, sourceId))
             .executeTakeFirstOrThrow();
 
           const source = await transaction
             .selectFrom("sources")
             .selectAll()
-            .where("id", "=", input.id)
+            .where("id", "=", sourceId)
             .executeTakeFirstOrThrow();
           const snapshot = await transaction
             .selectFrom("source_snapshots")
             .selectAll()
-            .where("source_id", "=", input.id)
-            .where("version", "=", 1)
+            .where("source_id", "=", sourceId)
+            .orderBy("version", "desc")
+            .executeTakeFirst();
+          const collectorSetting = await transaction
+            .selectFrom("collector_settings")
+            .select("id")
+            .where("source_id", "=", sourceId)
+            .orderBy("created_at", "asc")
             .executeTakeFirstOrThrow();
           const collectorSettingSnapshot = await transaction
             .selectFrom("collector_setting_snapshots")
             .selectAll()
-            .where("collector_setting_id", "=", input.collectorSettingId)
-            .where("version", "=", 1)
+            .where("collector_setting_id", "=", collectorSetting.id)
+            .orderBy("version", "desc")
+            .executeTakeFirst();
+          const subscription = await transaction
+            .selectFrom("subscriptions")
+            .selectAll()
+            .where("id", "=", input.subscriptionId)
             .executeTakeFirstOrThrow();
 
-          return toSourceListItem(source, snapshot, collectorSettingSnapshot);
+          const item = toSourceListItem(
+            source,
+            snapshot ?? null,
+            collectorSettingSnapshot ?? null,
+          );
+          return {
+            ...item,
+            collectionId: subscription.collection_id,
+            subscriptionId: subscription.id,
+            subscriptionPosition: subscription.position,
+          };
         }),
       );
     } catch (error) {
-      if (isDuplicateSourceUrlHashError(error)) {
+      if (
+        isDuplicateSourceUrlHashError(error) ||
+        isDuplicateSubscriptionError(error)
+      ) {
         return err(new DuplicateSourceUrlHashError(input.urlHash));
       }
 
@@ -145,16 +225,18 @@ export class SourceRepository {
     }
   }
 
-  public async listSources(): Promise<
-    Result<SourceListItem[], SourceRepositoryError>
-  > {
+  public async listSources(
+    userSlug: string,
+  ): Promise<Result<SourceListItem[], SourceRepositoryError>> {
     try {
       const latestSourceSnapshots = latestSourceSnapshotsQuery(this.database);
       const latestCollectorSettingSnapshots =
         latestCollectorSettingSnapshotsQuery(this.database);
 
       const sources = await this.database
-        .selectFrom("sources")
+        .selectFrom("subscriptions")
+        .innerJoin("users", "users.id", "subscriptions.user_id")
+        .innerJoin("sources", "sources.id", "subscriptions.source_id")
         .leftJoin(
           latestSourceSnapshots.as("latest_source_snapshots"),
           "latest_source_snapshots.source_id",
@@ -173,6 +255,10 @@ export class SourceRepository {
           "collector_settings.id",
         )
         .select([
+          "subscriptions.collection_id",
+          "subscriptions.id as subscription_id",
+          "subscriptions.created_at as subscription_created_at",
+          "subscriptions.position as subscription_position",
           "sources.created_at",
           "sources.id",
           "sources.kind",
@@ -187,12 +273,235 @@ export class SourceRepository {
           "latest_collector_setting_snapshots.periodical_interval_minutes",
           "latest_collector_setting_snapshots.version as collector_settings_version",
         ])
-        .orderBy("sources.created_at", "desc")
+        .where("users.slug", "=", userSlug)
+        .orderBy("subscriptions.collection_id", "asc")
+        .orderBy("subscriptions.position", "asc")
+        .orderBy("subscriptions.created_at", "desc")
         .execute();
       return ok(sources.map(toJoinedSourceListItem));
     } catch (error) {
       return err(
         error instanceof Error ? error : new Error("Failed to list sources."),
+      );
+    }
+  }
+
+  public async listCollections(
+    userSlug: string,
+  ): Promise<Result<SourceCollectionListItem[], SourceRepositoryError>> {
+    try {
+      const collections = await this.database
+        .selectFrom("collections")
+        .innerJoin("users", "users.id", "collections.user_id")
+        .leftJoin(
+          "subscriptions",
+          "subscriptions.collection_id",
+          "collections.id",
+        )
+        .select([
+          "collections.created_at",
+          "collections.id",
+          "collections.parent_collection_id",
+          "collections.position",
+          "collections.title",
+          sql<number>`count(subscriptions.id)`.as("source_count"),
+        ])
+        .where("users.slug", "=", userSlug)
+        .groupBy([
+          "collections.created_at",
+          "collections.id",
+          "collections.parent_collection_id",
+          "collections.position",
+          "collections.title",
+        ])
+        .orderBy("collections.position", "asc")
+        .orderBy("collections.created_at", "asc")
+        .execute();
+
+      return ok(
+        collections.map((collection) => ({
+          createdAt: collection.created_at,
+          id: collection.id,
+          parentCollectionId: collection.parent_collection_id,
+          position: collection.position,
+          sourceCount: collection.source_count,
+          title: collection.title,
+        })),
+      );
+    } catch (error) {
+      return err(
+        error instanceof Error
+          ? error
+          : new Error("Failed to list collections."),
+      );
+    }
+  }
+
+  public async createCollection(
+    input: CreateCollectionInput,
+  ): Promise<Result<SourceCollectionListItem, SourceRepositoryError>> {
+    try {
+      return ok(
+        await this.database.transaction().execute(async (transaction) => {
+          const user = await ensureUserBySlug(transaction, input.userSlug);
+          await transaction
+            .insertInto("collections")
+            .values({
+              id: input.id,
+              parent_collection_id: input.parentCollectionId ?? null,
+              position: input.position,
+              title: input.title,
+              user_id: user.id,
+            })
+            .executeTakeFirstOrThrow();
+
+          const collection = await transaction
+            .selectFrom("collections")
+            .selectAll()
+            .where("id", "=", input.id)
+            .executeTakeFirstOrThrow();
+
+          return toCollectionListItem(collection, 0);
+        }),
+      );
+    } catch (error) {
+      return err(
+        error instanceof Error
+          ? error
+          : new Error("Failed to create collection."),
+      );
+    }
+  }
+
+  public async updateCollection(
+    input: UpdateCollectionInput,
+  ): Promise<Result<SourceCollectionListItem | null, SourceRepositoryError>> {
+    try {
+      return ok(
+        await this.database.transaction().execute(async (transaction) => {
+          const user = await transaction
+            .selectFrom("users")
+            .select("id")
+            .where("slug", "=", input.userSlug)
+            .executeTakeFirst();
+
+          if (user === undefined) {
+            return null;
+          }
+
+          const collection = await transaction
+            .selectFrom("collections")
+            .selectAll()
+            .where("id", "=", input.collectionId)
+            .where("user_id", "=", user.id)
+            .executeTakeFirst();
+
+          if (collection === undefined) {
+            return null;
+          }
+
+          await transaction
+            .updateTable("collections")
+            .set({
+              parent_collection_id:
+                input.parentCollectionId === undefined
+                  ? collection.parent_collection_id
+                  : input.parentCollectionId,
+              position: input.position ?? collection.position,
+              title: input.title ?? collection.title,
+            })
+            .where("id", "=", input.collectionId)
+            .executeTakeFirstOrThrow();
+
+          const updatedCollection = await transaction
+            .selectFrom("collections")
+            .selectAll()
+            .where("id", "=", input.collectionId)
+            .executeTakeFirstOrThrow();
+          const subscriptionCountRow = await transaction
+            .selectFrom("subscriptions")
+            .select(sql<number>`count(id)`.as("count"))
+            .where("collection_id", "=", input.collectionId)
+            .executeTakeFirstOrThrow();
+
+          return toCollectionListItem(
+            updatedCollection,
+            subscriptionCountRow.count,
+          );
+        }),
+      );
+    } catch (error) {
+      return err(
+        error instanceof Error
+          ? error
+          : new Error("Failed to update collection."),
+      );
+    }
+  }
+
+  public async assignSourceToCollection(
+    userSlug: string,
+    sourceId: string,
+    collectionId: string | null,
+    position: number,
+  ): Promise<Result<SourceListItem | null, SourceRepositoryError>> {
+    try {
+      return ok(
+        await this.database.transaction().execute(async (transaction) => {
+          const user = await transaction
+            .selectFrom("users")
+            .select("id")
+            .where("slug", "=", userSlug)
+            .executeTakeFirst();
+
+          if (user === undefined) {
+            return null;
+          }
+
+          if (collectionId !== null) {
+            const collection = await transaction
+              .selectFrom("collections")
+              .select("id")
+              .where("id", "=", collectionId)
+              .where("user_id", "=", user.id)
+              .executeTakeFirst();
+
+            if (collection === undefined) {
+              return null;
+            }
+          }
+
+          const subscription = await transaction
+            .selectFrom("subscriptions")
+            .selectAll()
+            .where("source_id", "=", sourceId)
+            .where("user_id", "=", user.id)
+            .executeTakeFirst();
+
+          if (subscription === undefined) {
+            return null;
+          }
+
+          await transaction
+            .updateTable("subscriptions")
+            .set({
+              collection_id: collectionId,
+              position,
+            })
+            .where("id", "=", subscription.id)
+            .executeTakeFirstOrThrow();
+
+          return findSourceListItemBySubscriptionId(
+            transaction,
+            subscription.id,
+          );
+        }),
+      );
+    } catch (error) {
+      return err(
+        error instanceof Error
+          ? error
+          : new Error("Failed to assign source to collection."),
       );
     }
   }
@@ -366,6 +675,7 @@ export class SourceRepository {
   }
 
   public async updateSourceCollectorSettings(
+    userSlug: string,
     sourceId: string,
     settings: SourcePeriodicCrawlSettings,
     baseVersion: number,
@@ -416,34 +726,31 @@ export class SourceRepository {
               version: nextVersion,
             })
             .executeTakeFirstOrThrow();
-
-          const source = await transaction
-            .selectFrom("sources")
-            .selectAll()
-            .where("id", "=", sourceId)
-            .executeTakeFirstOrThrow();
-          const sourceSnapshot = await transaction
-            .selectFrom("source_snapshots")
-            .selectAll()
-            .where("source_id", "=", sourceId)
-            .orderBy("version", "desc")
+          const user = await transaction
+            .selectFrom("users")
+            .select("id")
+            .where("slug", "=", userSlug)
             .executeTakeFirst();
 
-          return {
-            collectorSettingsVersion: nextVersion,
-            createdAt: source.created_at,
-            description: sourceSnapshot?.description ?? null,
-            id: source.id,
-            kind: source.kind,
-            periodicCrawlEnabled: settings.enabled,
-            periodicCrawlIntervalMinutes: settings.intervalMinutes,
-            recordedAt: sourceSnapshot?.recorded_at ?? null,
-            slug: source.slug,
-            title: sourceSnapshot?.title ?? null,
-            url: source.url,
-            urlHash: source.url_hash,
-            version: sourceSnapshot?.version ?? null,
-          };
+          if (user === undefined) {
+            return null;
+          }
+
+          const subscription = await transaction
+            .selectFrom("subscriptions")
+            .select("id")
+            .where("source_id", "=", sourceId)
+            .where("user_id", "=", user.id)
+            .executeTakeFirst();
+
+          if (subscription === undefined) {
+            return null;
+          }
+
+          return findSourceListItemBySubscriptionId(
+            transaction,
+            subscription.id,
+          );
         }),
       );
     } catch (error) {
@@ -455,6 +762,62 @@ export class SourceRepository {
         error instanceof Error
           ? error
           : new Error("Failed to update source collector settings."),
+      );
+    }
+  }
+
+  public async unsubscribe(
+    userSlug: string,
+    subscriptionId: string,
+  ): Promise<Result<boolean, SourceRepositoryError>> {
+    try {
+      return ok(
+        await this.database.transaction().execute(async (transaction) => {
+          const user = await transaction
+            .selectFrom("users")
+            .select("id")
+            .where("slug", "=", userSlug)
+            .executeTakeFirst();
+
+          if (user === undefined) {
+            return false;
+          }
+
+          const subscription = await transaction
+            .selectFrom("subscriptions")
+            .selectAll()
+            .where("id", "=", subscriptionId)
+            .where("user_id", "=", user.id)
+            .executeTakeFirst();
+
+          if (subscription === undefined) {
+            return false;
+          }
+
+          const unsubscribedAt = new Date();
+
+          await transaction
+            .insertInto("subscription_events")
+            .values({
+              id: crypto.randomUUID(),
+              kind: "unsubscribed",
+              occurred_at: unsubscribedAt,
+              source_id: subscription.source_id,
+              user_id: subscription.user_id,
+            })
+            .executeTakeFirstOrThrow();
+
+          await transaction
+            .deleteFrom("subscriptions")
+            .where("id", "=", subscription.id)
+            .executeTakeFirstOrThrow();
+
+          return true;
+        }),
+      );
+    } catch (error) {
+      return err(
+        error instanceof Error ? error : new Error("Failed to unsubscribe."),
       );
     }
   }
@@ -502,6 +865,56 @@ function isCollectorSettingsVersionConflictError(error: unknown): boolean {
       error.message.includes(constraint) ||
       errorWithCode.detail?.includes(constraint) === true)
   );
+}
+
+function isDuplicateSubscriptionError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const constraint = "subscriptions_user_id_source_id_key";
+  const errorWithCode = error as Error & {
+    code?: string;
+    constraint?: string;
+    detail?: string;
+  };
+
+  return (
+    errorWithCode.code === "23505" &&
+    (errorWithCode.constraint === constraint ||
+      error.message.includes(constraint) ||
+      errorWithCode.detail?.includes(constraint) === true)
+  );
+}
+
+async function ensureUserBySlug(
+  database: Kysely<GeshiDatabase>,
+  userSlug: string,
+): Promise<Selectable<UserTable>> {
+  const existingUser = await database
+    .selectFrom("users")
+    .selectAll()
+    .where("slug", "=", userSlug)
+    .executeTakeFirst();
+
+  if (existingUser !== undefined) {
+    return existingUser;
+  }
+
+  const id = crypto.randomUUID();
+  await database
+    .insertInto("users")
+    .values({
+      id,
+      slug: userSlug,
+    })
+    .executeTakeFirstOrThrow();
+
+  return database
+    .selectFrom("users")
+    .selectAll()
+    .where("id", "=", id)
+    .executeTakeFirstOrThrow();
 }
 
 function toSourceInsert(input: CreateSourceInput): Insertable<SourceTable> {
@@ -553,12 +966,41 @@ function toCollectorSettingSnapshotInsert(
   };
 }
 
+function toSubscriptionInsert(
+  input: CreateSourceInput,
+  userId: string,
+  sourceId: string,
+): Insertable<SubscriptionTable> {
+  return {
+    collection_id: null,
+    id: input.subscriptionId,
+    position: 0,
+    source_id: sourceId,
+    user_id: userId,
+  };
+}
+
+function toSubscriptionEventInsert(
+  input: CreateSourceInput,
+  userId: string,
+  sourceId: string,
+): Insertable<SubscriptionEventTable> {
+  return {
+    id: input.subscriptionEventId,
+    kind: "subscribed",
+    occurred_at: new Date(),
+    source_id: sourceId,
+    user_id: userId,
+  };
+}
+
 function toSourceListItem(
   source: Selectable<SourceTable>,
   snapshot: Selectable<SourceSnapshotTable> | null,
   collectorSettingSnapshot: Selectable<CollectorSettingSnapshotTable> | null,
 ): SourceListItem {
   return {
+    collectionId: null,
     collectorSettingsVersion: collectorSettingSnapshot?.version ?? null,
     periodicCrawlEnabled: collectorSettingSnapshot?.periodical ?? false,
     periodicCrawlIntervalMinutes:
@@ -570,6 +1012,8 @@ function toSourceListItem(
     kind: source.kind,
     recordedAt: snapshot?.recorded_at ?? null,
     slug: source.slug,
+    subscriptionId: "",
+    subscriptionPosition: 0,
     title: snapshot?.title ?? null,
     url: source.url,
     urlHash: source.url_hash,
@@ -597,6 +1041,7 @@ function toObserveSourceTarget(
 }
 
 function toJoinedSourceListItem(source: {
+  collection_id: string | null;
   collector_settings_version: number | null;
   created_at: Date;
   description: string | null;
@@ -606,12 +1051,16 @@ function toJoinedSourceListItem(source: {
   periodical_interval_minutes: number | null;
   recorded_at: Date | null;
   slug: string;
+  subscription_id: string;
   title: string | null;
   url: string;
   url_hash: string;
   version: number | null;
+  subscription_created_at: Date;
+  subscription_position: number;
 }): SourceListItem {
   return {
+    collectionId: source.collection_id,
     collectorSettingsVersion: source.collector_settings_version,
     periodicCrawlEnabled: source.enabled ?? false,
     periodicCrawlIntervalMinutes:
@@ -623,11 +1072,78 @@ function toJoinedSourceListItem(source: {
     kind: source.kind,
     recordedAt: source.recorded_at,
     slug: source.slug,
+    subscriptionId: source.subscription_id,
+    subscriptionPosition: source.subscription_position,
     title: source.title,
     url: source.url,
     urlHash: source.url_hash,
     version: source.version,
   };
+}
+
+function toCollectionListItem(
+  collection: Selectable<CollectionTable>,
+  sourceCount: number,
+): SourceCollectionListItem {
+  return {
+    createdAt: collection.created_at,
+    id: collection.id,
+    parentCollectionId: collection.parent_collection_id,
+    position: collection.position,
+    sourceCount,
+    title: collection.title,
+  };
+}
+
+async function findSourceListItemBySubscriptionId(
+  database: Kysely<GeshiDatabase>,
+  subscriptionId: string,
+): Promise<SourceListItem | null> {
+  const latestSourceSnapshots = latestSourceSnapshotsQuery(database);
+  const latestCollectorSettingSnapshots =
+    latestCollectorSettingSnapshotsQuery(database);
+
+  const row = await database
+    .selectFrom("subscriptions")
+    .innerJoin("sources", "sources.id", "subscriptions.source_id")
+    .leftJoin(
+      latestSourceSnapshots.as("latest_source_snapshots"),
+      "latest_source_snapshots.source_id",
+      "sources.id",
+    )
+    .leftJoin(
+      "collector_settings",
+      "collector_settings.source_id",
+      "sources.id",
+    )
+    .leftJoin(
+      latestCollectorSettingSnapshots.as("latest_collector_setting_snapshots"),
+      "latest_collector_setting_snapshots.collector_setting_id",
+      "collector_settings.id",
+    )
+    .select([
+      "subscriptions.collection_id",
+      "subscriptions.id as subscription_id",
+      "subscriptions.created_at as subscription_created_at",
+      "subscriptions.position as subscription_position",
+      "sources.created_at",
+      "sources.id",
+      "sources.kind",
+      "sources.slug",
+      "sources.url",
+      "sources.url_hash",
+      "latest_source_snapshots.description",
+      "latest_source_snapshots.recorded_at",
+      "latest_source_snapshots.title",
+      "latest_source_snapshots.version",
+      "latest_collector_setting_snapshots.enabled",
+      "latest_collector_setting_snapshots.periodical_interval_minutes",
+      "latest_collector_setting_snapshots.version as collector_settings_version",
+    ])
+    .where("subscriptions.id", "=", subscriptionId)
+    .executeTakeFirst();
+
+  return row === undefined ? null : toJoinedSourceListItem(row);
 }
 
 function latestSourceSnapshotsQuery(database: Kysely<GeshiDatabase>) {

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -28,6 +28,38 @@ export type SourceTable = {
   url_hash: string;
 };
 
+export type UserTable = {
+  created_at: TimestampColumn;
+  id: string;
+  slug: string;
+};
+
+export type SubscriptionTable = {
+  collection_id: string | null;
+  created_at: TimestampColumn;
+  id: string;
+  position: NumberColumn;
+  source_id: string;
+  user_id: string;
+};
+
+export type SubscriptionEventTable = {
+  id: string;
+  kind: "subscribed" | "unsubscribed";
+  occurred_at: TimestampColumn;
+  source_id: string;
+  user_id: string;
+};
+
+export type CollectionTable = {
+  created_at: TimestampColumn;
+  id: string;
+  parent_collection_id: string | null;
+  position: NumberColumn;
+  title: string;
+  user_id: string;
+};
+
 export type SourceSnapshotTable = {
   description: string | null;
   id: string;
@@ -212,14 +244,18 @@ export type GeshiDatabase = {
   collector_plugin_state_snapshots: CollectorPluginStateSnapshotTable;
   collector_setting_snapshots: CollectorSettingSnapshotTable;
   collector_settings: CollectorSettingTable;
+  collections: CollectionTable;
   content_snapshots: ContentSnapshotTable;
   contents: ContentTable;
   detail_bodies: DetailBodyTable;
   jobs: JobTable;
   plugin_global_runtime_states: PluginGlobalRuntimeStateTable;
   plugin_global_runtime_state_snapshots: PluginGlobalRuntimeStateSnapshotTable;
-  transcript_chunks: TranscriptChunkTable;
-  transcripts: TranscriptTable;
   source_snapshots: SourceSnapshotTable;
   sources: SourceTable;
+  subscription_events: SubscriptionEventTable;
+  subscriptions: SubscriptionTable;
+  transcript_chunks: TranscriptChunkTable;
+  transcripts: TranscriptTable;
+  users: UserTable;
 };

--- a/backend/src/endpoints/api/v1/sources.ts
+++ b/backend/src/endpoints/api/v1/sources.ts
@@ -1,5 +1,8 @@
 import type { JobListItem } from "../../../db/job-repository.js";
-import type { SourceListItem } from "../../../db/source-repository.js";
+import type {
+  SourceCollectionListItem,
+  SourceListItem,
+} from "../../../db/source-repository.js";
 import {
   CollectorSettingsVersionConflictError,
   DuplicateSourceUrlHashError,
@@ -20,10 +23,50 @@ import type {
   SourceCollectorSettingValue,
 } from "../../../service/source-service.js";
 
+export type ListSourceCollectionsEndpointError = {
+  code: "source_collection_list_failed";
+  message: string;
+};
+
+export type CreateSourceCollectionEndpointError = {
+  code: "source_collection_create_failed";
+  message: string;
+};
+
+export type UpdateSourceCollectionEndpointError =
+  | {
+      code: "collection_not_found";
+      message: string;
+    }
+  | {
+      code: "source_collection_update_failed";
+      message: string;
+    };
+
+export type AssignSourceToCollectionEndpointError =
+  | {
+      code: "collection_not_found";
+      message: string;
+    }
+  | {
+      code: "source_collection_assign_failed";
+      message: string;
+    };
+
 export type ListSourcesEndpointError = {
   code: "source_list_failed";
   message: string;
 };
+
+export type UnsubscribeEndpointError =
+  | {
+      code: "subscription_not_found";
+      message: string;
+    }
+  | {
+      code: "subscription_unsubscribe_failed";
+      message: string;
+    };
 
 export type ListSourceCollectorPluginsEndpointError = {
   code: "source_collector_plugin_list_failed";
@@ -107,6 +150,23 @@ export type PatchSourceCollectorSettingsEndpointInput = {
   items: Array<{ key: string; value: SourceCollectorSettingValue }>;
 };
 
+export type CreateSourceCollectionEndpointInput = {
+  parentCollectionId?: string | null;
+  position: number;
+  title?: string;
+};
+
+export type AssignSourceToCollectionEndpointInput = {
+  collectionId?: string | null;
+  position: number;
+};
+
+export type UpdateSourceCollectionEndpointInput = {
+  parentCollectionId?: string | null;
+  position: number;
+  title?: string;
+};
+
 export function createListSourcesEndpoint(dependencies: AppDependencies) {
   return async (): Promise<
     Result<SourceListItem[], ListSourcesEndpointError>
@@ -121,6 +181,47 @@ export function createListSourcesEndpoint(dependencies: AppDependencies) {
     }
 
     return sources;
+  };
+}
+
+export function createUnsubscribeEndpoint(dependencies: AppDependencies) {
+  return async (
+    subscriptionId: string,
+  ): Promise<Result<void, UnsubscribeEndpointError>> => {
+    const result = await dependencies.sourceService.unsubscribe(subscriptionId);
+
+    if (!result.ok) {
+      if (result.error instanceof Error) {
+        return err({
+          code: "subscription_unsubscribe_failed",
+          message: result.error.message,
+        });
+      }
+
+      return err(result.error);
+    }
+
+    return ok(undefined);
+  };
+}
+
+export function createListSourceCollectionsEndpoint(
+  dependencies: AppDependencies,
+) {
+  return async (): Promise<
+    Result<SourceCollectionListItem[], ListSourceCollectionsEndpointError>
+  > => {
+    const collections =
+      await dependencies.sourceService.listSourceCollections();
+
+    if (!collections.ok) {
+      return err({
+        code: "source_collection_list_failed",
+        message: collections.error.message,
+      });
+    }
+
+    return collections;
   };
 }
 
@@ -196,6 +297,90 @@ export function createCreateSourceEndpoint(dependencies: AppDependencies) {
       if (result.error instanceof Error) {
         return err({
           code: "source_create_failed",
+          message: result.error.message,
+        });
+      }
+
+      return err(result.error);
+    }
+
+    return result;
+  };
+}
+
+export function createCreateSourceCollectionEndpoint(
+  dependencies: AppDependencies,
+) {
+  return async (
+    input: CreateSourceCollectionEndpointInput,
+  ): Promise<
+    Result<SourceCollectionListItem, CreateSourceCollectionEndpointError>
+  > => {
+    const result = await dependencies.sourceService.createCollection(
+      input.title ?? "",
+      input.position,
+      input.parentCollectionId,
+    );
+
+    if (!result.ok) {
+      return err({
+        code: "source_collection_create_failed",
+        message: result.error.message,
+      });
+    }
+
+    return result;
+  };
+}
+
+export function createAssignSourceToCollectionEndpoint(
+  dependencies: AppDependencies,
+) {
+  return async (
+    sourceId: string,
+    input: AssignSourceToCollectionEndpointInput,
+  ): Promise<Result<SourceListItem, AssignSourceToCollectionEndpointError>> => {
+    const result = await dependencies.sourceService.assignSourceToCollection(
+      sourceId,
+      input.collectionId ?? null,
+      input.position,
+    );
+
+    if (!result.ok) {
+      if (result.error instanceof Error) {
+        return err({
+          code: "source_collection_assign_failed",
+          message: result.error.message,
+        });
+      }
+
+      return err(result.error);
+    }
+
+    return result;
+  };
+}
+
+export function createUpdateSourceCollectionEndpoint(
+  dependencies: AppDependencies,
+) {
+  return async (
+    collectionId: string,
+    input: UpdateSourceCollectionEndpointInput,
+  ): Promise<
+    Result<SourceCollectionListItem, UpdateSourceCollectionEndpointError>
+  > => {
+    const result = await dependencies.sourceService.updateCollection(
+      collectionId,
+      input.title ?? "",
+      input.position,
+      input.parentCollectionId,
+    );
+
+    if (!result.ok) {
+      if (result.error instanceof Error) {
+        return err({
+          code: "source_collection_update_failed",
           message: result.error.message,
         });
       }

--- a/backend/src/routes/api/v1/collections.ts
+++ b/backend/src/routes/api/v1/collections.ts
@@ -1,0 +1,181 @@
+import type { Context } from "hono";
+import { Hono } from "hono";
+
+import type { AppDependencies } from "../../../deps.js";
+import type {
+  CreateSourceCollectionEndpointInput,
+  UpdateSourceCollectionEndpointInput,
+} from "../../../endpoints/api/v1/sources.js";
+import {
+  createCreateSourceCollectionEndpoint,
+  createListSourceCollectionsEndpoint,
+  createUpdateSourceCollectionEndpoint,
+} from "../../../endpoints/api/v1/sources.js";
+import type { Result } from "../../../lib/result.js";
+import { err, ok } from "../../../lib/result.js";
+
+export function createCollectionRoutes(dependencies: AppDependencies): Hono {
+  const router = new Hono();
+  const listSourceCollections =
+    createListSourceCollectionsEndpoint(dependencies);
+  const createSourceCollection =
+    createCreateSourceCollectionEndpoint(dependencies);
+  const updateSourceCollection =
+    createUpdateSourceCollectionEndpoint(dependencies);
+
+  router.get("/", async (context) => {
+    const result = await listSourceCollections();
+
+    if (!result.ok) {
+      return context.json({ error: result.error }, { status: 500 });
+    }
+
+    return context.json({ data: result.value });
+  });
+
+  router.post("/", async (context) => {
+    const json = await readJsonObject(context);
+
+    if (!json.ok) {
+      return context.json({ error: json.error }, { status: 400 });
+    }
+
+    const input = toCreateSourceCollectionEndpointInput(json.value);
+
+    if (!input.ok) {
+      return context.json({ error: input.error }, { status: 422 });
+    }
+
+    const result = await createSourceCollection(input.value);
+
+    if (!result.ok) {
+      return context.json({ error: result.error }, { status: 500 });
+    }
+
+    return context.json({ data: result.value }, { status: 201 });
+  });
+
+  router.patch("/:collectionId", async (context) => {
+    const json = await readJsonObject(context);
+
+    if (!json.ok) {
+      return context.json({ error: json.error }, { status: 400 });
+    }
+
+    const input = toUpdateSourceCollectionEndpointInput(json.value);
+
+    if (!input.ok) {
+      return context.json({ error: input.error }, { status: 422 });
+    }
+
+    const result = await updateSourceCollection(
+      requireRouteParam(context.req.param("collectionId"), "collectionId"),
+      input.value,
+    );
+
+    if (!result.ok) {
+      return context.json(
+        { error: result.error },
+        {
+          status: result.error.code === "collection_not_found" ? 404 : 500,
+        },
+      );
+    }
+
+    return context.json({ data: result.value });
+  });
+
+  return router;
+}
+
+function requireRouteParam(value: string | undefined, name: string): string {
+  if (value === undefined) {
+    throw new Error(`Missing route param: ${name}`);
+  }
+
+  return value;
+}
+
+async function readJsonObject(
+  context: Context,
+): Promise<
+  Result<Record<string, unknown>, { code: "invalid_json"; message: string }>
+> {
+  let json: unknown;
+
+  try {
+    json = await context.req.json();
+  } catch {
+    return err({
+      code: "invalid_json",
+      message: "Request body must be a JSON object.",
+    });
+  }
+
+  if (json === null || typeof json !== "object") {
+    return err({
+      code: "invalid_json",
+      message: "Request body must be a JSON object.",
+    });
+  }
+
+  return ok(json as Record<string, unknown>);
+}
+
+function toCreateSourceCollectionEndpointInput(
+  value: Record<string, unknown>,
+): Result<
+  CreateSourceCollectionEndpointInput,
+  { code: "invalid_source_collection"; message: string }
+> {
+  if (
+    typeof value.title !== "string" ||
+    value.title.trim() === "" ||
+    !isNullablePositiveIntegerOrZero(value.position)
+  ) {
+    return err({
+      code: "invalid_source_collection",
+      message:
+        "Source collection requires non-empty title and non-negative position.",
+    });
+  }
+
+  return ok({
+    parentCollectionId: toOptionalString(value.parentCollectionId) ?? null,
+    position: value.position,
+    title: value.title.trim(),
+  });
+}
+
+function toUpdateSourceCollectionEndpointInput(
+  value: Record<string, unknown>,
+): Result<
+  UpdateSourceCollectionEndpointInput,
+  { code: "invalid_source_collection_update"; message: string }
+> {
+  if (
+    typeof value.title !== "string" ||
+    value.title.trim() === "" ||
+    !isNullablePositiveIntegerOrZero(value.position)
+  ) {
+    return err({
+      code: "invalid_source_collection_update",
+      message:
+        "Source collection update requires non-empty title and non-negative position.",
+    });
+  }
+
+  return ok({
+    parentCollectionId: toOptionalString(value.parentCollectionId) ?? null,
+    position: value.position,
+    title: value.title.trim(),
+  });
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isNullablePositiveIntegerOrZero(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}

--- a/backend/src/routes/api/v1/sources.ts
+++ b/backend/src/routes/api/v1/sources.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 
 import type { AppDependencies } from "../../../deps.js";
 import type {
+  AssignSourceToCollectionEndpointInput,
   CreateSourceEndpointInput,
   DiscoverSourcesEndpointInput,
   InspectSourceEndpointInput,
@@ -10,6 +11,7 @@ import type {
   PreviewSourceEndpointInput,
 } from "../../../endpoints/api/v1/sources.js";
 import {
+  createAssignSourceToCollectionEndpoint,
   createCreateSourceEndpoint,
   createDiscoverSourcesEndpoint,
   createEnqueueObserveSourceEndpoint,
@@ -46,6 +48,8 @@ export function createSourceRoutes(dependencies: AppDependencies): Hono {
   const inspectSource = createInspectSourceEndpoint(dependencies);
   const previewSource = createPreviewSourceEndpoint(dependencies);
   const enqueueObserveSource = createEnqueueObserveSourceEndpoint(dependencies);
+  const assignSourceToCollection =
+    createAssignSourceToCollectionEndpoint(dependencies);
   const getSourceCollectorSettings =
     createGetSourceCollectorSettingsEndpoint(dependencies);
   const patchSourceCollectorSettings =
@@ -250,6 +254,35 @@ export function createSourceRoutes(dependencies: AppDependencies): Hono {
 
     return context.json({ data: result.value });
   });
+  router.patch("/:sourceId/collection", async (context) => {
+    const json = await readJsonObject(context);
+
+    if (!json.ok) {
+      return context.json({ error: json.error }, { status: 400 });
+    }
+
+    const input = toAssignSourceToCollectionEndpointInput(json.value);
+
+    if (!input.ok) {
+      return context.json({ error: input.error }, { status: 422 });
+    }
+
+    const result = await assignSourceToCollection(
+      requireRouteParam(context.req.param("sourceId"), "sourceId"),
+      input.value,
+    );
+
+    if (!result.ok) {
+      return context.json(
+        { error: result.error },
+        {
+          status: result.error.code === "collection_not_found" ? 404 : 500,
+        },
+      );
+    }
+
+    return context.json({ data: result.value });
+  });
 
   return router;
 }
@@ -353,12 +386,35 @@ function toPatchSourceCollectorSettingsEndpointInput(
   });
 }
 
+function toAssignSourceToCollectionEndpointInput(
+  value: Record<string, unknown>,
+): Result<
+  AssignSourceToCollectionEndpointInput,
+  { code: "invalid_source_collection_assignment"; message: string }
+> {
+  if (!isNullablePositiveIntegerOrZero(value.position)) {
+    return err({
+      code: "invalid_source_collection_assignment",
+      message: "Source collection assignment requires non-negative position.",
+    });
+  }
+
+  return ok({
+    collectionId: toOptionalString(value.collectionId) ?? null,
+    position: value.position,
+  });
+}
+
 function toOptionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
 function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isNullablePositiveIntegerOrZero(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 function isCollectorSettingItems(

--- a/backend/src/routes/api/v1/subscriptions.ts
+++ b/backend/src/routes/api/v1/subscriptions.ts
@@ -1,0 +1,40 @@
+import { Hono } from "hono";
+
+import type { AppDependencies } from "../../../deps.js";
+import { createUnsubscribeEndpoint } from "../../../endpoints/api/v1/sources.js";
+
+export function createSubscriptionRoutes(dependencies: AppDependencies): Hono {
+  const router = new Hono();
+  const unsubscribe = createUnsubscribeEndpoint(dependencies);
+
+  router.delete("/:subscriptionId", async (context) => {
+    const subscriptionId = context.req.param("subscriptionId");
+
+    if (subscriptionId === undefined) {
+      return context.json(
+        {
+          error: {
+            code: "invalid_subscription",
+            message: "Subscription id is required.",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    const result = await unsubscribe(subscriptionId);
+
+    if (!result.ok) {
+      return context.json(
+        { error: result.error },
+        {
+          status: result.error.code === "subscription_not_found" ? 404 : 500,
+        },
+      );
+    }
+
+    return context.body(null, 204);
+  });
+
+  return router;
+}

--- a/backend/src/service/source-service.ts
+++ b/backend/src/service/source-service.ts
@@ -1,8 +1,10 @@
 import type {
   CollectorSettingsVersionConflictError,
+  CreateCollectionInput,
   DuplicateSourceUrlHashError,
   ObserveSourceTarget,
   PeriodicCrawlSourceTarget,
+  SourceCollectionListItem,
   SourceCollectorSettingsRecord,
   SourceListItem,
   SourceRepository,
@@ -55,6 +57,16 @@ export type GetSourceCollectorSettingsError = {
   message: string;
 };
 
+export type SourceCollectionError = {
+  code: "collection_not_found";
+  message: string;
+};
+
+export type SubscriptionError = {
+  code: "subscription_not_found";
+  message: string;
+};
+
 export type SourceCollectorPluginListItem = {
   message: string | null;
   description: string | null;
@@ -79,6 +91,29 @@ export type SourceCollectorSettingsDetail = {
 };
 
 export interface SourceService {
+  assignSourceToCollection(
+    sourceId: string,
+    collectionId: string | null,
+    position: number,
+  ): Promise<
+    Result<SourceListItem, SourceCollectionError | SourceRepositoryError>
+  >;
+  createCollection(
+    title: string,
+    position: number,
+    parentCollectionId?: string | null,
+  ): Promise<Result<SourceCollectionListItem, SourceRepositoryError>>;
+  updateCollection(
+    collectionId: string,
+    title: string,
+    position: number,
+    parentCollectionId?: string | null,
+  ): Promise<
+    Result<
+      SourceCollectionListItem,
+      SourceCollectionError | SourceRepositoryError
+    >
+  >;
   createSource(
     request: CreateSourceRequest,
   ): Promise<Result<SourceListItem, CreateSourceError>>;
@@ -99,10 +134,16 @@ export interface SourceService {
     >
   >;
   listSourceCollectorPlugins(): Result<SourceCollectorPluginListItem[], Error>;
+  listSourceCollections(): Promise<
+    Result<SourceCollectionListItem[], SourceRepositoryError>
+  >;
   listPeriodicCrawlTargets(): Promise<
     Result<PeriodicCrawlSourceTarget[], SourceRepositoryError>
   >;
   listSources(): Promise<Result<SourceListItem[], SourceRepositoryError>>;
+  unsubscribe(
+    subscriptionId: string,
+  ): Promise<Result<void, SubscriptionError | SourceRepositoryError>>;
   updateSourceCollectorSettings(
     sourceId: string,
     settings: SourcePeriodicCrawlSettings,
@@ -122,6 +163,8 @@ export type CreateSourceServiceDependencies = {
   logger?: Logger;
   sourceCollectorRegistry?: SourceCollectorRegistry;
 };
+
+const DEFAULT_SOURCE_USER_SLUG = "default";
 
 export function createSourceService(
   sourceRepository: SourceRepository,
@@ -145,6 +188,81 @@ export function createSourceService(
     dependencies.sourceCollectorRegistry ?? defaultSourceCollectorRegistry;
 
   return {
+    async assignSourceToCollection(
+      sourceId: string,
+      collectionId: string | null,
+      position: number,
+    ): Promise<
+      Result<SourceListItem, SourceCollectionError | SourceRepositoryError>
+    > {
+      const result = await sourceRepository.assignSourceToCollection(
+        DEFAULT_SOURCE_USER_SLUG,
+        sourceId,
+        collectionId,
+        position,
+      );
+
+      if (!result.ok) {
+        return result;
+      }
+
+      if (result.value === null) {
+        return err({
+          code: "collection_not_found",
+          message: "Collection or source not found.",
+        });
+      }
+
+      return ok(result.value);
+    },
+
+    async createCollection(
+      title: string,
+      position: number,
+      parentCollectionId?: string | null,
+    ): Promise<Result<SourceCollectionListItem, SourceRepositoryError>> {
+      return sourceRepository.createCollection({
+        id: crypto.randomUUID(),
+        parentCollectionId,
+        position,
+        title,
+        userSlug: DEFAULT_SOURCE_USER_SLUG,
+      } satisfies CreateCollectionInput);
+    },
+
+    async updateCollection(
+      collectionId: string,
+      title: string,
+      position: number,
+      parentCollectionId?: string | null,
+    ): Promise<
+      Result<
+        SourceCollectionListItem,
+        SourceCollectionError | SourceRepositoryError
+      >
+    > {
+      const result = await sourceRepository.updateCollection({
+        collectionId,
+        parentCollectionId,
+        position,
+        title,
+        userSlug: DEFAULT_SOURCE_USER_SLUG,
+      });
+
+      if (!result.ok) {
+        return result;
+      }
+
+      if (result.value === null) {
+        return err({
+          code: "collection_not_found",
+          message: "Collection not found.",
+        });
+      }
+
+      return ok(result.value);
+    },
+
     async createSource(
       request: CreateSourceRequest,
     ): Promise<Result<SourceListItem, CreateSourceError>> {
@@ -183,9 +301,12 @@ export function createSourceService(
         pluginSlug,
         slug,
         snapshotId: crypto.randomUUID(),
+        subscriptionEventId: crypto.randomUUID(),
+        subscriptionId: crypto.randomUUID(),
         title: normalizeOptionalString(request.title),
         url: normalizedUrl,
         urlHash: createUrlHash(normalizedUrl),
+        userSlug: DEFAULT_SOURCE_USER_SLUG,
       });
 
       if (!result.ok) {
@@ -301,10 +422,38 @@ export function createSourceService(
       return sourceRepository.listPeriodicCrawlTargets();
     },
 
+    async listSourceCollections(): Promise<
+      Result<SourceCollectionListItem[], SourceRepositoryError>
+    > {
+      return sourceRepository.listCollections(DEFAULT_SOURCE_USER_SLUG);
+    },
+
     async listSources(): Promise<
       Result<SourceListItem[], SourceRepositoryError>
     > {
-      return sourceRepository.listSources();
+      return sourceRepository.listSources(DEFAULT_SOURCE_USER_SLUG);
+    },
+
+    async unsubscribe(
+      subscriptionId: string,
+    ): Promise<Result<void, SubscriptionError | SourceRepositoryError>> {
+      const result = await sourceRepository.unsubscribe(
+        DEFAULT_SOURCE_USER_SLUG,
+        subscriptionId,
+      );
+
+      if (!result.ok) {
+        return result;
+      }
+
+      if (!result.value) {
+        return err({
+          code: "subscription_not_found",
+          message: "Subscription not found.",
+        });
+      }
+
+      return ok(undefined);
     },
 
     async updateSourceCollectorSettings(
@@ -342,6 +491,7 @@ export function createSourceService(
         ...Object.fromEntries(items.map((item) => [item.key, item.value])),
       };
       const source = await sourceRepository.updateSourceCollectorSettings(
+        DEFAULT_SOURCE_USER_SLUG,
         sourceId,
         settings,
         baseVersion,

--- a/backend/test/app.test.ts
+++ b/backend/test/app.test.ts
@@ -25,6 +25,36 @@ describe("createApp", () => {
     const app = createApp(dependencies);
 
     expect((await app.request("/api/v1/sources")).status).toBe(200);
+    expect((await app.request("/api/v1/collections")).status).toBe(200);
+    expect(
+      (
+        await app.request("/api/v1/collections", {
+          body: JSON.stringify({
+            position: 0,
+            title: "Work",
+          }),
+          headers: {
+            "content-type": "application/json",
+          },
+          method: "POST",
+        })
+      ).status,
+    ).toBe(201);
+    expect(
+      (
+        await app.request("/api/v1/collections/collection-1", {
+          body: JSON.stringify({
+            parentCollectionId: null,
+            position: 1,
+            title: "Pinned",
+          }),
+          headers: {
+            "content-type": "application/json",
+          },
+          method: "PATCH",
+        })
+      ).status,
+    ).toBe(200);
     expect(
       (
         await app.request("/api/v1/sources/inspect", {
@@ -38,6 +68,27 @@ describe("createApp", () => {
         })
       ).status,
     ).toBe(200);
+    expect(
+      (
+        await app.request("/api/v1/sources/source-1/collection", {
+          body: JSON.stringify({
+            collectionId: "collection-1",
+            position: 0,
+          }),
+          headers: {
+            "content-type": "application/json",
+          },
+          method: "PATCH",
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await app.request("/api/v1/subscriptions/subscription-1", {
+          method: "DELETE",
+        })
+      ).status,
+    ).toBe(204);
     expect((await app.request("/api/v1/contents")).status).toBe(200);
     expect((await app.request("/api/v1/jobs/job-1")).status).toBe(200);
     expect((await app.request("/api/v1/settings/periodic-crawl")).status).toBe(

--- a/backend/test/endpoints/sources.test.ts
+++ b/backend/test/endpoints/sources.test.ts
@@ -6,15 +6,20 @@ import {
   DuplicateSourceUrlHashError,
 } from "../../src/db/source-repository.js";
 import {
+  createAssignSourceToCollectionEndpoint,
+  createCreateSourceCollectionEndpoint,
   createCreateSourceEndpoint,
   createDiscoverSourcesEndpoint,
   createEnqueueObserveSourceEndpoint,
   createGetSourceCollectorSettingsEndpoint,
   createInspectSourceEndpoint,
+  createListSourceCollectionsEndpoint,
   createListSourceCollectorPluginsEndpoint,
   createListSourcesEndpoint,
   createPatchSourceCollectorSettingsEndpoint,
   createPreviewSourceEndpoint,
+  createUnsubscribeEndpoint,
+  createUpdateSourceCollectionEndpoint,
 } from "../../src/endpoints/api/v1/sources.js";
 import { err, ok } from "../../src/lib/result.js";
 import type { JobService } from "../../src/service/job-service.js";
@@ -34,6 +39,7 @@ describe("source endpoints", () => {
             Promise.resolve(
               ok([
                 {
+                  collectionId: null,
                   collectorSettingsVersion: 1,
                   createdAt: new Date("2026-05-01T00:00:00.000Z"),
                   description: null,
@@ -43,6 +49,8 @@ describe("source endpoints", () => {
                   periodicCrawlIntervalMinutes: 60,
                   recordedAt: null,
                   slug: "example-feed",
+                  subscriptionId: "subscription-1",
+                  subscriptionPosition: 0,
                   title: "Example Feed",
                   url: "https://example.com/feed.xml",
                   urlHash: "hash-1",
@@ -148,9 +156,12 @@ describe("source endpoints", () => {
           inspectSource: vi.fn(),
         },
         sourceService: {
+          assignSourceToCollection: vi.fn(),
+          createCollection: vi.fn(),
           createSource: vi.fn(() =>
             Promise.resolve(
               ok({
+                collectionId: null,
                 collectorSettingsVersion: 1,
                 createdAt: new Date("2026-05-01T00:00:00.000Z"),
                 description: "Weekly notes",
@@ -160,6 +171,8 @@ describe("source endpoints", () => {
                 periodicCrawlIntervalMinutes: 60,
                 recordedAt: null,
                 slug: "example-feed",
+                subscriptionId: "subscription-1",
+                subscriptionPosition: 0,
                 title: "Example Feed",
                 url: "https://example.com/feed.xml",
                 urlHash: "hash-1",
@@ -170,8 +183,11 @@ describe("source endpoints", () => {
           findObserveSourceTarget: vi.fn(),
           getSourceCollectorSettings: vi.fn(),
           listSourceCollectorPlugins: () => ok([]),
+          listSourceCollections: vi.fn(),
           listPeriodicCrawlTargets: vi.fn(),
           listSources: vi.fn(),
+          unsubscribe: vi.fn(),
+          updateCollection: vi.fn(),
           updateSourceCollectorSettings: vi.fn(),
         } satisfies SourceService,
       }),
@@ -190,6 +206,187 @@ describe("source endpoints", () => {
         title: "Example Feed",
       }),
     );
+  });
+
+  it("returns source collections", async () => {
+    const endpoint = createListSourceCollectionsEndpoint(
+      createTestAppDependencies({
+        sourceService: {
+          listSourceCollections: vi.fn(() =>
+            Promise.resolve(
+              ok([
+                {
+                  createdAt: new Date("2026-06-02T00:00:00.000Z"),
+                  id: "collection-1",
+                  parentCollectionId: null,
+                  position: 0,
+                  sourceCount: 1,
+                  title: "Work",
+                },
+              ]),
+            ),
+          ),
+        } as unknown as SourceService,
+      }),
+    );
+
+    await expect(endpoint()).resolves.toEqual(
+      ok([
+        {
+          createdAt: new Date("2026-06-02T00:00:00.000Z"),
+          id: "collection-1",
+          parentCollectionId: null,
+          position: 0,
+          sourceCount: 1,
+          title: "Work",
+        },
+      ]),
+    );
+  });
+
+  it("creates source collections", async () => {
+    const endpoint = createCreateSourceCollectionEndpoint(
+      createTestAppDependencies({
+        sourceService: {
+          createCollection: vi.fn(() =>
+            Promise.resolve(
+              ok({
+                createdAt: new Date("2026-06-02T00:00:00.000Z"),
+                id: "collection-1",
+                parentCollectionId: null,
+                position: 0,
+                sourceCount: 0,
+                title: "Work",
+              }),
+            ),
+          ),
+        } as unknown as SourceService,
+      }),
+    );
+
+    await expect(
+      endpoint({
+        parentCollectionId: null,
+        position: 0,
+        title: "Work",
+      }),
+    ).resolves.toEqual(
+      ok({
+        createdAt: new Date("2026-06-02T00:00:00.000Z"),
+        id: "collection-1",
+        parentCollectionId: null,
+        position: 0,
+        sourceCount: 0,
+        title: "Work",
+      }),
+    );
+  });
+
+  it("updates source collections", async () => {
+    const endpoint = createUpdateSourceCollectionEndpoint(
+      createTestAppDependencies({
+        sourceService: {
+          updateCollection: vi.fn(() =>
+            Promise.resolve(
+              ok({
+                createdAt: new Date("2026-06-02T00:00:00.000Z"),
+                id: "collection-1",
+                parentCollectionId: null,
+                position: 1,
+                sourceCount: 2,
+                title: "Pinned",
+              }),
+            ),
+          ),
+        } as unknown as SourceService,
+      }),
+    );
+
+    await expect(
+      endpoint("collection-1", {
+        parentCollectionId: null,
+        position: 1,
+        title: "Pinned",
+      }),
+    ).resolves.toEqual(
+      ok({
+        createdAt: new Date("2026-06-02T00:00:00.000Z"),
+        id: "collection-1",
+        parentCollectionId: null,
+        position: 1,
+        sourceCount: 2,
+        title: "Pinned",
+      }),
+    );
+  });
+
+  it("assigns sources to collections", async () => {
+    const endpoint = createAssignSourceToCollectionEndpoint(
+      createTestAppDependencies({
+        sourceService: {
+          assignSourceToCollection: vi.fn(() =>
+            Promise.resolve(
+              ok({
+                collectionId: "collection-1",
+                collectorSettingsVersion: 1,
+                createdAt: new Date("2026-06-02T00:00:00.000Z"),
+                description: "Weekly notes",
+                id: "source-1",
+                kind: "podcast",
+                periodicCrawlEnabled: true,
+                periodicCrawlIntervalMinutes: 60,
+                recordedAt: new Date("2026-06-02T00:00:00.000Z"),
+                slug: "example-feed",
+                subscriptionId: "subscription-1",
+                subscriptionPosition: 2,
+                title: "Example Feed",
+                url: "https://example.com/feed.xml",
+                urlHash: "hash-1",
+                version: 1,
+              }),
+            ),
+          ),
+        } as unknown as SourceService,
+      }),
+    );
+
+    await expect(
+      endpoint("source-1", {
+        collectionId: "collection-1",
+        position: 2,
+      }),
+    ).resolves.toEqual(
+      ok({
+        collectionId: "collection-1",
+        collectorSettingsVersion: 1,
+        createdAt: new Date("2026-06-02T00:00:00.000Z"),
+        description: "Weekly notes",
+        id: "source-1",
+        kind: "podcast",
+        periodicCrawlEnabled: true,
+        periodicCrawlIntervalMinutes: 60,
+        recordedAt: new Date("2026-06-02T00:00:00.000Z"),
+        slug: "example-feed",
+        subscriptionId: "subscription-1",
+        subscriptionPosition: 2,
+        title: "Example Feed",
+        url: "https://example.com/feed.xml",
+        urlHash: "hash-1",
+        version: 1,
+      }),
+    );
+  });
+
+  it("unsubscribes subscriptions", async () => {
+    const endpoint = createUnsubscribeEndpoint(
+      createTestAppDependencies({
+        sourceService: {
+          unsubscribe: vi.fn(() => Promise.resolve(ok(undefined))),
+        } as unknown as SourceService,
+      }),
+    );
+
+    await expect(endpoint("subscription-1")).resolves.toEqual(ok(undefined));
   });
 
   it("preserves duplicate-source errors", async () => {

--- a/backend/test/service/source-service.test.ts
+++ b/backend/test/service/source-service.test.ts
@@ -50,6 +50,7 @@ describe("source service", () => {
     const createSource = vi.fn((input: CreateSourceInput) =>
       Promise.resolve(
         ok({
+          collectionId: null,
           collectorSettingsVersion: 1,
           createdAt: new Date("2026-05-01T00:00:00.000Z"),
           description: input.description ?? null,
@@ -59,6 +60,8 @@ describe("source service", () => {
           periodicCrawlIntervalMinutes: 60,
           recordedAt: null,
           slug: input.slug,
+          subscriptionId: "subscription-1",
+          subscriptionPosition: 0,
           title: input.title ?? null,
           url: input.url,
           urlHash: input.urlHash,
@@ -95,6 +98,7 @@ describe("source service", () => {
       pluginSlug: "podcast-rss",
       title: "Example Feed",
       url: "https://example.com/feed.xml",
+      userSlug: "default",
     });
     expect(createSourceInput?.slug).toMatch(/^example-feed/);
   });
@@ -245,6 +249,44 @@ describe("source service", () => {
     expect(result.value).toEqual(targets);
   });
 
+  it("maps missing subscriptions to subscription_not_found", async () => {
+    const service = createSourceService(
+      {
+        unsubscribe: vi.fn(() => Promise.resolve(ok(false))),
+      } as unknown as SourceRepository,
+      {
+        logger: createNoopLogger(),
+        sourceCollectorRegistry,
+      },
+    );
+
+    const result = await service.unsubscribe("subscription-1");
+
+    assertErr(result);
+    expect(result.error).toEqual({
+      code: "subscription_not_found",
+      message: "Subscription not found.",
+    });
+  });
+
+  it("unsubscribes existing subscriptions", async () => {
+    const unsubscribe = vi.fn(() => Promise.resolve(ok(true)));
+    const service = createSourceService(
+      {
+        unsubscribe,
+      } as unknown as SourceRepository,
+      {
+        logger: createNoopLogger(),
+        sourceCollectorRegistry,
+      },
+    );
+
+    const result = await service.unsubscribe("subscription-1");
+
+    assertOk(result);
+    expect(unsubscribe).toHaveBeenCalledWith("default", "subscription-1");
+  });
+
   it("lists source collector plugins from the registry", () => {
     sourceCollectorRegistry.list = vi.fn(() => [
       {
@@ -334,6 +376,7 @@ describe("source service", () => {
   it("lists sources from repository", async () => {
     const sources = [
       {
+        collectionId: null,
         collectorSettingsVersion: 1,
         createdAt: new Date("2026-05-01T00:00:00.000Z"),
         description: null,
@@ -343,18 +386,21 @@ describe("source service", () => {
         periodicCrawlIntervalMinutes: 60,
         recordedAt: null,
         slug: "example-feed",
+        subscriptionId: "subscription-1",
+        subscriptionPosition: 0,
         title: "Example Feed",
         url: "https://example.com/feed.xml",
         urlHash: "hash-1",
         version: 1,
       },
     ] satisfies SourceListItem[];
+    const listSources = vi.fn(() => Promise.resolve(ok(sources)));
     const service = createSourceService(
       {
         createSource: vi.fn(),
         findObserveSourceTarget: vi.fn(),
         listPeriodicCrawlTargets: vi.fn(),
-        listSources: vi.fn(() => Promise.resolve(ok(sources))),
+        listSources,
         updateSourceCollectorSettings: vi.fn(),
       } as unknown as SourceRepository,
       {
@@ -367,6 +413,7 @@ describe("source service", () => {
 
     assertOk(result);
     expect(result.value).toEqual(sources);
+    expect(listSources).toHaveBeenCalledWith("default");
   });
 
   it("maps missing collector settings updates to source_not_found", async () => {
@@ -404,6 +451,7 @@ describe("source service", () => {
   it("returns updated collector settings from repository", async () => {
     const source = {
       collectorSettingsVersion: 2,
+      collectionId: null,
       createdAt: new Date("2026-05-01T00:00:00.000Z"),
       description: null,
       id: "source-1",
@@ -412,6 +460,8 @@ describe("source service", () => {
       periodicCrawlIntervalMinutes: 30,
       recordedAt: null,
       slug: "example-feed",
+      subscriptionId: "subscription-1",
+      subscriptionPosition: 0,
       title: "Example Feed",
       url: "https://example.com/feed.xml",
       urlHash: "hash-1",
@@ -501,6 +551,7 @@ describe("source service", () => {
     const createSource = vi.fn((input: CreateSourceInput) =>
       Promise.resolve(
         ok({
+          collectionId: null,
           collectorSettingsVersion: 1,
           createdAt: new Date("2026-05-01T00:00:00.000Z"),
           description: input.description ?? null,
@@ -510,6 +561,8 @@ describe("source service", () => {
           periodicCrawlIntervalMinutes: 60,
           recordedAt: null,
           slug: input.slug,
+          subscriptionId: "subscription-2",
+          subscriptionPosition: 0,
           title: input.title ?? null,
           url: input.url,
           urlHash: input.urlHash,

--- a/backend/test/support/app-dependencies.ts
+++ b/backend/test/support/app-dependencies.ts
@@ -176,6 +176,7 @@ export function createTestAppDependencies(
       createSource: vi.fn(() =>
         Promise.resolve(
           ok({
+            collectionId: null,
             collectorSettingsVersion: 1,
             createdAt: new Date("2026-05-01T00:00:00.000Z"),
             description: null,
@@ -185,6 +186,8 @@ export function createTestAppDependencies(
             periodicCrawlIntervalMinutes: 60,
             recordedAt: null,
             slug: "example-feed",
+            subscriptionId: "subscription-1",
+            subscriptionPosition: 0,
             title: "Example Feed",
             url: "https://example.com/feed.xml",
             urlHash: "hash-1",
@@ -216,10 +219,10 @@ export function createTestAppDependencies(
           }),
         ),
       ),
-      listSources: vi.fn(() => Promise.resolve(ok([]))),
-      updateSourceCollectorSettings: vi.fn(() =>
+      assignSourceToCollection: vi.fn(() =>
         Promise.resolve(
           ok({
+            collectionId: null,
             collectorSettingsVersion: 1,
             createdAt: new Date("2026-05-01T00:00:00.000Z"),
             description: null,
@@ -229,6 +232,57 @@ export function createTestAppDependencies(
             periodicCrawlIntervalMinutes: 60,
             recordedAt: null,
             slug: "example-feed",
+            subscriptionId: "subscription-1",
+            subscriptionPosition: 0,
+            title: "Example Feed",
+            url: "https://example.com/feed.xml",
+            urlHash: "hash-1",
+            version: 1,
+          }),
+        ),
+      ),
+      createCollection: vi.fn(() =>
+        Promise.resolve(
+          ok({
+            createdAt: new Date("2026-05-01T00:00:00.000Z"),
+            id: "collection-1",
+            parentCollectionId: null,
+            position: 0,
+            sourceCount: 0,
+            title: "Default",
+          }),
+        ),
+      ),
+      listSources: vi.fn(() => Promise.resolve(ok([]))),
+      listSourceCollections: vi.fn(() => Promise.resolve(ok([]))),
+      unsubscribe: vi.fn(() => Promise.resolve(ok(undefined))),
+      updateCollection: vi.fn(() =>
+        Promise.resolve(
+          ok({
+            createdAt: new Date("2026-05-01T00:00:00.000Z"),
+            id: "collection-1",
+            parentCollectionId: null,
+            position: 0,
+            sourceCount: 0,
+            title: "Default",
+          }),
+        ),
+      ),
+      updateSourceCollectorSettings: vi.fn(() =>
+        Promise.resolve(
+          ok({
+            collectionId: null,
+            collectorSettingsVersion: 1,
+            createdAt: new Date("2026-05-01T00:00:00.000Z"),
+            description: null,
+            id: "source-1",
+            kind: "podcast",
+            periodicCrawlEnabled: true,
+            periodicCrawlIntervalMinutes: 60,
+            recordedAt: null,
+            slug: "example-feed",
+            subscriptionId: "subscription-1",
+            subscriptionPosition: 0,
             title: "Example Feed",
             url: "https://example.com/feed.xml",
             urlHash: "hash-1",

--- a/db/data-migrations/0014-source-subscriptions.sql
+++ b/db/data-migrations/0014-source-subscriptions.sql
@@ -1,0 +1,72 @@
+begin;
+
+create extension if not exists pgcrypto;
+
+-- 既存の source を単一利用者前提の default user subscription へ移行する。
+-- 再実行時の整合は固定 ID ではなく unique 制約と存在確認で担保する。
+
+insert into users (
+  id,
+  slug
+)
+select
+  gen_random_uuid(),
+  'default'
+where not exists (
+  select 1
+  from users
+  where slug = 'default'
+);
+
+insert into subscriptions (
+  id,
+  user_id,
+  source_id,
+  collection_id,
+  position
+)
+select
+  gen_random_uuid(),
+  users.id,
+  sources.id,
+  null,
+  0
+from sources
+cross join (
+  select id
+  from users
+  where slug = 'default'
+) as users
+where not exists (
+  select 1
+  from subscriptions
+  where subscriptions.user_id = users.id
+    and subscriptions.source_id = sources.id
+);
+
+insert into subscription_events (
+  id,
+  user_id,
+  source_id,
+  kind,
+  occurred_at
+)
+select
+  gen_random_uuid(),
+  subscriptions.user_id,
+  subscriptions.source_id,
+  'subscribed',
+  subscriptions.created_at
+from subscriptions
+inner join users
+  on users.id = subscriptions.user_id
+where users.slug = 'default'
+  and not exists (
+    select 1
+    from subscription_events
+    where subscription_events.user_id = subscriptions.user_id
+      and subscription_events.source_id = subscriptions.source_id
+      and subscription_events.kind = 'subscribed'
+  );
+
+commit;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -9,6 +9,45 @@ create table sources (
     created_at timestamptz not null default current_timestamp
 );
 
+create table users (
+    id uuid primary key,
+    slug varchar(128) not null unique,
+    created_at timestamptz not null default current_timestamp
+);
+
+create table subscriptions (
+    id uuid primary key,
+    user_id uuid not null references users (id),
+    source_id uuid not null references sources (id),
+    collection_id uuid,
+    position integer not null default 0,
+    created_at timestamptz not null default current_timestamp,
+    constraint subscriptions_user_id_source_id_key unique (user_id, source_id)
+);
+
+create table collections (
+    id uuid primary key,
+    user_id uuid not null references users (id),
+    parent_collection_id uuid references collections (id),
+    title text not null,
+    position integer not null default 0,
+    created_at timestamptz not null default current_timestamp
+);
+
+alter table subscriptions
+    add constraint subscriptions_collection_id_fkey
+    foreign key (collection_id) references collections (id);
+
+create table subscription_events (
+    id uuid primary key,
+    user_id uuid not null references users (id),
+    source_id uuid not null references sources (id),
+    kind text not null constraint subscription_events_kind_check check (
+        kind = any(array ['subscribed'::text, 'unsubscribed'::text])
+    ),
+    occurred_at timestamptz not null default current_timestamp
+);
+
 create table source_snapshots (
     id uuid primary key,
     source_id uuid not null references sources (id),
@@ -219,6 +258,28 @@ create table transcript_chunks (
 );
 
 create index if not exists sources_created_at_idx on sources (created_at);
+
+create index if not exists users_slug_idx on users (slug);
+
+create index if not exists subscriptions_user_id_idx on subscriptions (user_id);
+
+create index if not exists subscriptions_source_id_idx on subscriptions (source_id);
+
+create index if not exists subscriptions_collection_id_idx on subscriptions (collection_id);
+
+create index if not exists subscription_events_user_id_occurred_at_idx on subscription_events (
+    user_id,
+    occurred_at desc
+);
+create index if not exists subscription_events_source_id_occurred_at_idx on subscription_events (
+    source_id,
+    occurred_at desc
+);
+
+create index if not exists collections_user_id_position_idx on collections (
+    user_id,
+    position
+);
 
 create index if not exists source_snapshots_version_idx on source_snapshots (version);
 

--- a/docs/acceptance/0014-source-collections-and-browse-layouts.md
+++ b/docs/acceptance/0014-source-collections-and-browse-layouts.md
@@ -1,0 +1,52 @@
+# Source Collections And Browse Layouts
+
+この開発項目では，user が source を subscription し，その subscription を整理するための上位概念として collection を導入できることを受け入れ条件とする．
+利用者は subscription を collection へ出し入れでき，collection 自体の並び替えと subscription の所属変更を drag and drop で操作できる．
+また source 一覧の表示は，collection を前提にした Windows Explorer 風の 1 行表示と，現状のフラットな一覧表示を切り替えて利用できることを今回の完了条件とする．
+あわせて，subscription / collection / 全体設定をぶら下げる親主体として user 概念を導入し，今回追加する整理機能が user 境界に所属することも完了条件に含める．
+
+## 受け入れ条件
+
+- user が source を subscription できる
+- source は user 固有資源ではなく，共有可能な収集対象として扱える
+- source に対する user ごとの関係は subscription として表現される
+- subscription，collection，全体設定の親主体として user が追加される
+- subscription と collection は user に所属し，異なる user の資源と混線しない前提で扱える
+- 今回の UI / 運用では単一利用者で成立してよいが，永続化構造と API は user / subscription 概念を欠落させない
+- 将来 billing / plan の意味での subscription のような契約・利用条件の主体を追加しても，user / source subscription 構造と衝突しない前提で設計される
+- collection は source とは独立した識別子と表示名を持ち，source 一覧や関連 API から扱える
+- collection のデータ構造は，将来的な多階層化を妨げない形で定義される
+- 今回の UI / 運用要件としては 1 階層で十分であり，利用者向け表示と操作は 1 階層として成立する
+- collection を作成できる
+- collection を名称変更できる
+- collection を並び替えできる
+- subscription を collection に追加できる
+- subscription を collection から外せる
+- subscription を collection 間で移動できる
+- collection の並び替えと subscription の出し入れ，移動は drag and drop で行える
+- drag and drop 操作の結果は永続化され，画面再読み込み後も維持される
+- source 一覧表示に，collection を前提にした Windows Explorer 風の 1 行表示モードが追加される
+- source 一覧表示に，現状のフラットな一覧表示モードが維持される
+- 利用者は 2 つの表示モードを UI 上で切り替えられる
+- collection に所属していない subscription も扱え，未所属 subscription が UI 上で見失われない
+- collection 表示モードでは，collection とその配下 subscription の関係が明確に分かる
+- フラット表示モードでは，collection 導入後も既存の source 一覧利用に近い見え方と操作性を保つ
+- backend に，subscription と collection の作成，更新，並び順管理，所属更新を扱える API と永続化実装が追加される
+- backend に，source / subscription / collection / 全体設定を user 境界で扱う永続化実装と API 前提が追加される
+- frontend に，collection 表示，表示モード切替，drag and drop 操作，subscription 所属変更結果の反映を扱える UI 実装が追加される
+- 主要な正常系と異常系について，backend / frontend / e2e のいずれか適切な粒度で自動確認が追加されている
+
+## 確認方法
+
+- collection を 2 件以上作成し，一覧上で表示されることを確認する
+- user が source を subscription でき，同じ source を複数 user が参照できる前提でも user ごとの subscription が混線しないことを確認する
+- subscription / collection / 全体設定が同一 user 配下の資源として扱われ，別 user 資源と混線しない前提で主要処理が確認できることを確認する
+- collection 名を変更し，表示へ反映され，再読み込み後も維持されることを確認する
+- collection の順序を drag and drop で入れ替え，表示順が更新され，再読み込み後も維持されることを確認する
+- subscription を未所属状態から collection へ追加できることを確認する
+- subscription をある collection から別 collection へ drag and drop で移動できることを確認する
+- subscription を collection から外し，未所属として扱えることを確認する
+- source 一覧表示を collection 表示モードへ切り替え，collection と subscription の関係が 1 行表示で確認できることを確認する
+- source 一覧表示をフラット表示モードへ切り替え，collection 導入前に近い一覧利用ができることを確認する
+- 表示モード切替後に source 選択や基本操作が破綻しないことを確認する
+- collection / subscription 所属 / 表示モード切替について，主要経路が自動テストで確認されることを確認する

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -20,9 +20,46 @@
 
 ## 主体テーブル
 
+### user
+
+利用主体を表す．
+
+例:
+
+- `geshi` を利用する個人
+- 将来的な複数利用者の各主体
+
+主な属性:
+
+- `id`
+- `slug`
+- `createdAt`
+
+### subscription
+
+user が source を購読している現在の関係を表す．
+
+例:
+
+- ある user が特定 podcast を購読している状態
+- ある user が特定 RSS / Atom feed を一覧へ出している状態
+
+主な属性:
+
+- `id`
+- `userId`
+- `sourceId`
+- `createdAt`
+
+補足:
+
+- source 登録時には，対応する subscription も同時に発生する前提とする
+- 将来，register 時に既存 source が見つかった場合は，source を再利用して subscription だけを作る形を許容する
+- unsubscribe では現在の subscription 関係を解除し，履歴は event 側へ残す
+
 ### source
 
-継続的に収集する対象を表す．
+継続的に収集する共有対象を表す．
 
 例:
 
@@ -38,6 +75,50 @@
 - `url`
 - `urlHash`
 - `createdAt`
+
+補足:
+
+- source は user 固有資源ではない
+- 複数 user が同じ source を subscription できる
+
+### collection
+
+user が自分の subscription を整理する grouping 単位を表す．
+
+例:
+
+- 日常的に見る購読対象を入れるフォルダ
+- topic / project / environment ごとの購読整理フォルダ
+
+主な属性:
+
+- `id`
+- `userId`
+- `parentCollectionId`
+- `createdAt`
+
+補足:
+
+- 今回の UI / 運用要件は 1 階層でよい
+- ただし data structure は将来の多階層化を妨げない前提にする
+- collection は source ではなく subscription を整理する
+
+### collectionSubscription
+
+collection と subscription の現在の所属関係を表す．
+
+主な属性:
+
+- `id`
+- `collectionId`
+- `subscriptionId`
+- `position`
+- `createdAt`
+
+補足:
+
+- drag and drop の結果を永続化するため，順序を持てるようにする
+- unsubscribe により subscription 関係を解除したときは，現在の所属関係もあわせて解消する前提で考える
 
 ### content
 
@@ -193,6 +274,25 @@ chunk 分割された文字起こしの部分結果を表す．
 - `sourceStartMs` / `sourceEndMs` は元音声内での時間範囲を表す
 
 ## 履歴テーブル
+
+### subscriptionEvent
+
+subscription に対して起きた出来事を表す．
+
+主な属性:
+
+- `id`
+- `subscriptionId`
+- `kind`
+  - `subscribed`
+  - `unsubscribed`
+- `occurredAt`
+
+補足:
+
+- current state と履歴を分けるため，subscribe / unsubscribe の記録は event として保持する
+- 「今購読しているか」は主体側の current relationship を見て判断する
+- 「いつ購読し，いつ解除したか」は event 側を見る
 
 ### sourceSnapshot
 

--- a/docs/decisions/0005-data-model.md
+++ b/docs/decisions/0005-data-model.md
@@ -11,6 +11,7 @@
 ## コンテキスト
 
 - `geshi` は podcast，streaming，feed を継続的に収集し，保存し，あとから閲覧・検索・再利用する個人用アーカイブである
+- `geshi` は将来的に複数 user が同じ source を共有しつつ，購読関係や整理状態は user ごとに持てるようにしたい
 - 収集対象には feed のようなテキスト主体のものと，podcast や streaming のようなメディア主体のものが混在する
 - 同じ source から複数の content が発生し，1 つの content が複数の asset や transcript を持ちうる
 - source や content の可変属性には履歴を追いたいものが含まれる
@@ -23,8 +24,14 @@
 
 ### 主体テーブル
 
+- `user`
+  - 利用主体を表す
+- `subscription`
+  - user が source を購読している現在の関係を表す
 - `source`
-  - 継続収集の対象を表す
+  - 継続収集の共有対象を表す
+- `collection`
+  - user が subscription を整理する単位を表す
 - `content`
   - 閲覧・検索の基本単位を表す
 - `asset`
@@ -34,16 +41,33 @@
 
 ### 履歴テーブル
 
+- `subscriptionEvent`
+  - subscribe / unsubscribe の履歴を表す
 - `sourceSnapshot`
   - source の可変属性のある時点の状態を表す
 - `contentSnapshot`
   - content の可変属性のある時点の状態を表す
+
+### user / subscription / source を分ける
+
+- `user` は利用主体とする
+- `source` は共有可能な収集対象とする
+- `subscription` は user が source を購読している現在の関係とする
+- source 登録時には subscription も同時に発生する前提で扱う
+- unsubscribe では current relationship を解除し，履歴は `subscriptionEvent` に残す
+- 1 つの `source` は複数の `subscription` から参照されうる
 
 ### source と content を分ける
 
 - `source` は継続購読・巡回の対象とする
 - `content` は閲覧・再生・検索・保存の基本単位とする
 - 1 つの `source` は複数の `content` を持つ
+
+### collection は subscription を整理する
+
+- `collection` は user に属する
+- `collection` は source ではなく subscription を整理する
+- collection 階層は将来拡張できる形を許容するが，当面の UI 要件は 1 階層とする
 
 ### content を中心に関連情報をぶら下げる
 
@@ -80,6 +104,7 @@
 ## 影響
 
 - crawler は `source` を起点に収集処理を組みやすくなる
+- user ごとの購読関係や整理状態を source 本体から分けて扱いやすくなる
 - source や content の変化を snapshot として保存できる
 - backend は `content` を基準に API と検索結果を設計しやすくなる
 - storage は `asset` を単位にファイル管理しやすくなる
@@ -91,6 +116,8 @@
   - 種別ごとの実装は単純だが，横断検索や共通 UI を作りにくい
 - source と content を分けず，取得物をすべて 1 単位で扱う
   - 初期実装は軽いが，継続収集と個別閲覧の責務が混ざりやすい
+- source と user の関係を直接 source 側へ埋め込む
+  - source 共有や user ごとの整理状態を表しにくいため採らない
 - 可変属性を主体テーブルに上書きし，`updatedAt` だけを持つ
   - 現在値は見やすいが，履歴要件を満たしにくい
 - ファイル本体も metadata ストア側に寄せる

--- a/docs/decisions/0068-source-collections-for-organization.md
+++ b/docs/decisions/0068-source-collections-for-organization.md
@@ -1,0 +1,87 @@
+# ADR-0068: user が source を subscription し，その subscription を collection で整理できるようにする
+
+## ステータス
+
+決定
+
+## 範囲
+
+全体
+
+## コンテキスト
+
+- 現在の source 一覧はフラットな集合として扱われており，source 数が増えたときの整理手段が弱い
+- `source.kind` や plugin 設定は収集上の分類であり，利用者が後から整理するための分類軸とは責務が異なる
+- source 自体は共有可能な収集対象として扱いたく，利用者ごとの差異は source そのものではなく subscription 側へ寄せたい
+- 利用者は自分が subscription している source を用途や関心単位でまとめ，順序づけ，あとから出し入れしたい
+- 今回の UI 要件では collection 階層は 1 階層で足りるが，永続化構造まで 1 階層固定にすると将来拡張時に詰まりやすい
+- 現状のフラットな source 一覧にも利用価値があり，collection 導入後も切り替えて併用したい
+
+## 決定
+
+user が source を subscription し，その subscription を collection で整理するための上位概念として `collection` を導入し，`source` 本体とも `subscription` とも別主体として扱う．
+
+### collection を source / subscription と分ける
+
+- `source` は継続収集対象の識別として維持する
+- `subscription` は user がどの source を購読しているかを表す利用者境界の主体として扱う
+- `collection` は利用者が subscription を整理するための grouping 単位として扱う
+- source の収集種別や plugin 適用条件と，利用者による整理軸を混在させない
+
+### collection 構造
+
+- `collection` は独立した識別子を持つ
+- `collection` は将来的な多階層化を妨げない構造を持つ
+- 具体的には parent を持てる設計を許容する
+- ただし今回の利用者向け UI と要件は 1 階層のみを対象とする
+
+### source / subscription / collection の関係
+
+- user は source を subscription する
+- subscription は 1 つの source を参照する
+- collection は user に属する subscription をまとめる
+- collection への所属関係は source 本体の属性へ埋め込まず，subscription と collection の関連として持つ
+- collection に所属していない subscription も正規の状態として扱う
+
+### 順序
+
+- collection 自体の表示順を保持できるようにする
+- collection 内での subscription の表示順，または所属関係に付随する順序を保持できるようにする
+- これにより drag and drop の結果を永続化できるようにする
+
+### browse UI
+
+- source 一覧には少なくとも 2 つの表示モードを持たせる
+- 1 つは collection を前提にした Windows Explorer 風の 1 行表示とする
+- もう 1 つは現状のフラット一覧に近い表示とする
+- 利用者は UI 上で表示モードを切り替えられるようにする
+
+## 影響
+
+- backend は source 一覧 API に加えて subscription，collection，所属関係を扱う API / 永続化が必要になる
+- frontend は browse 状態として表示モードと collection ベースの subscription 表示状態を扱う必要がある
+- source 一覧の UI は collection 導入後もフラット表示を残すため，一括移行ではなく切替対応になる
+- 今回の UI は 1 階層で成立させつつ，永続化構造は将来の多階層拡張を阻害しない前提で設計する必要がある
+
+## 代替案
+
+- `sources` に `folder` や `category` のような単一属性を直接追加する
+  - 実装は軽いが，利用者ごとの差異，複数所属，順序，未所属，階層化に弱い
+- tag 的な自由ラベルだけを追加する
+  - 横断分類には向くが，Explorer 風の browse 体験や順序づけの基盤としては弱い
+- collection 表示へ全面移行し，フラット表示を廃止する
+  - UI は単純になるが，既存の一覧利用に対する後方互換性を落とす
+
+## 備考
+
+- 具体的なテーブル構成，API 形状，D&D イベント処理の詳細は別途設計する
+
+## 参考資料
+
+- [ADR-0005] ADR-0005 データモデルを主体テーブルと履歴テーブルで構成する
+- [ADR-0027] ADR-0027 web ui frontend の browse state を URL に写す
+- [Acceptance-0014] Acceptance-0014 Source Collections And Browse Layouts
+
+[ADR-0005]: ./0005-data-model.md
+[ADR-0027]: ./0027-web-ui-browse-state-routing.md
+[Acceptance-0014]: ../acceptance/0014-source-collections-and-browse-layouts.md

--- a/docs/decisions/0069-user-as-ownership-root.md
+++ b/docs/decisions/0069-user-as-ownership-root.md
@@ -1,0 +1,93 @@
+# ADR-0069: source 整理機能に先立って user を所有主体として導入する
+
+## ステータス
+
+決定
+
+## 範囲
+
+全体
+
+## コンテキスト
+
+- `collection` を導入すると，subscription や全体設定を誰のものとして扱うかという所有境界が露出しやすくなる
+- 現在の実装には `app_settings.profile_slug` があるが，これは全体設定の識別子であり，source や browse 整理の所有主体としては明示されていない
+- source と subscription と collection を user 境界なしで追加すると，後から複数利用者や所有権境界を導入するときに table 関係や API 契約の見直し範囲が広がる
+- 一方で，現時点の product / UI 要件は単一利用者として成立してよく，直ちに認証や権限制御まで必要としているわけではない
+- 将来的に billing / plan の意味での subscription のような契約主体やプラン境界を導入する可能性があり，所有主体である user や source 購読関係としての subscription と混同しない前提を先に置きたい
+
+## 決定
+
+source 整理機能に先立って，`user` を subscription / collection / 全体設定の所有主体として導入する．
+
+### user の位置づけ
+
+- `user` は利用者資源の親主体とする
+- subscription，collection，全体設定，今後の利用者固有設定は user に所属させる
+- source は user 固有資源ではなく，共有可能な収集対象として扱う
+- 今回の導入目的は ownership 境界の明示であり，認証機構の追加そのものではない
+- `user` は billing / plan の意味での subscription や課金プランの代替概念としては扱わない
+
+### 現時点の利用形態
+
+- 当面の UI と運用は単一 user 前提で成立してよい
+- ただし永続化構造，repository，service，API は user 概念を欠落させない
+- 初期導入では default user のような単一主体を用意してもよい
+- 認証，認可，billing / plan の意味での subscription，請求，プラン制御は後続設計として分離する
+
+### source / subscription / collection の関係
+
+- user は source を subscription する
+- source に対する user ごとの関係は subscription として表現する
+- collection は source ではなく subscription を整理する
+- source 購読関係としての subscription は user に所属する
+
+### billing / plan subscription との関係
+
+- billing / plan の意味での subscription は，将来必要なら user に関連づく契約主体または利用条件主体として別概念で導入する
+- source や collection の ownership を billing / plan subscription に直接ぶら下げない
+- 今回の user 導入は，将来 billing / plan subscription を追加するときにも ownership と契約条件を分けて扱えるようにするための前提とする
+
+### 既存 `profile` との関係
+
+- `app_settings.profile_slug` は，将来的には user にひもづく全体設定識別の一部として再整理する
+- 新規設計では `profile` を user の代替概念として拡張しない
+- user 導入後は，subscription / collection と全体設定の ownership 表現を揃える方向で進める
+
+### collection との関係
+
+- collection は user に所属する
+- subscription も user に所属する
+- collection への所属は，同一 user 配下の subscription どうしの関係として扱う
+
+## 影響
+
+- DB schema は source に加えて，subscription や collection の親主体として user を表現する必要がある
+- backend API は現在の単一利用者運用を保ちながらも，内部では user 境界を意識した実装へ寄る
+- `app_settings` と今後の browse / organization 系機能の ownership 境界を subscription / collection 単位まで含めて段階的に揃えやすくなる
+- 認証や権限制御を後から追加するとき，資源所有モデルを再定義する負担を下げられる
+- billing / plan subscription を後から追加するとき，ownership と契約条件の責務を分けて設計しやすくなる
+
+## 代替案
+
+- 今回は collection だけ入れ，user や source subscription は後回しにする
+  - 初期実装は軽いが，ownership 境界の後付けコストが増える
+- `profile` をそのまま user 相当へ拡張する
+  - 既存実装との接続はしやすいが，全体設定識別と資源所有主体が混ざりやすい
+- 認証導入まで user を一切入れない
+  - 当面は単純だが，subscription / collection / settings の親主体が曖昧なまま残る
+
+## 備考
+
+- この ADR は user を ownership root として導入する判断を定めるものであり，認証方式，session，権限モデルまでは定めない
+- source 購読関係としての subscription の具体 schema や API 形状，billing / plan subscription や請求モデルも本 ADR では定めない
+
+## 参考資料
+
+- [ADR-0030] ADR-0030 定期実行クローラの設定は source ごとの設定から分けて管理する
+- [ADR-0068] ADR-0068 user が source を subscription し，その subscription を collection で整理できるようにする
+- [Acceptance-0014] Acceptance-0014 Source Collections And Browse Layouts
+
+[ADR-0030]: ./0030-configuration-management.md
+[ADR-0068]: ./0068-source-collections-for-organization.md
+[Acceptance-0014]: ../acceptance/0014-source-collections-and-browse-layouts.md

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -68,3 +68,5 @@
 - [ADR-0065: pluginSlug 単位の共有設定入力は source 設定と分けて schema 経由で管理する](./0065-plugin-global-settings-input.md)
 - [ADR-0066: source collector plugin に detect / preview 向け登録前 API を追加する](./0066-source-registration-detect-and-preview-plugin-api.md)
 - [ADR-0067: web ui frontend の source 登録フローを detect / preview / register に再構成する](./0067-web-ui-source-registration-detect-preview-flow.md)
+- [ADR-0068: user が source を subscription し，その subscription を collection で整理できるようにする](./0068-source-collections-for-organization.md)
+- [ADR-0069: source 整理機能に先立って user を所有主体として導入する](./0069-user-as-ownership-root.md)

--- a/docs/design-log/0068-source-subscription-model.md
+++ b/docs/design-log/0068-source-subscription-model.md
@@ -24,6 +24,19 @@
 - 将来，再 subscription が起こりうる
 - current state と event history を 1 つの列や 1 行だけで持つと，再購読や履歴照会が窮屈になりやすい
 
+## 現時点で採る前提
+
+- source 登録時に，その user に対する subscription も同時に発生する
+- つまり，現在の register 操作は user 視点では subscribe を含む
+- 将来 user が増えたときは，register 時に既存の source が見つかれば，新しい source を複製するのではなく，その source への subscription を作る形に寄せる
+
+この前提により，register は次の 2 通りを取りうる．
+
+- 新規 source を作成し，同時に subscription を作る
+- 既存 source を再利用し，subscription だけを作る
+
+user が触る操作名としては当面 register のままでもよいが，内部 model としては「source の確保」と「subscription の作成」を分けて考える．
+
 ## 現時点の有力案
 
 ### 1. subscription は主体 model として持つ
@@ -95,31 +108,31 @@ collection 所属については，少なくとも次の 2 案がある．
 
 ## unsubscribe 時の扱いで未決なこと
 
-### 1. subscription row を再利用するか
+### 1. unsubscribe では current relationship を外し，履歴は event へ残す
+
+現時点では次を採る．
+
+- unsubscribe では，current state としての subscription relationship は解除する
+- subscribe / unsubscribe の履歴は `subscription_event` に残す
+- 再 subscription 時は，新たな current relationship を作り，履歴側へ event を積む
+
+この方針では，current state と履歴を明確に分ける．
+
+- 「今購読しているか」は current relationship を見る
+- 「いつ購読し，いつ解除したか」は event を見る
+
+### 2. unsubscribe 時に collection 所属をどうするか
 
 案:
 
-- unsubscribe しても `subscription` row 自体は残す
-- 再 subscription 時は同じ `subscription` を active 側へ戻す
-- そのたびに `subscription_event` を追加する
-
-良さそうな点:
-
-- collection 所属や購読単位設定を維持しやすい
-- user から見た「同じ購読対象」に対する連続した履歴を持ちやすい
-
-### 2. unsubscribe 時に collection 所属を残すか
-
-案:
-
-- inactive な subscription でも collection 所属は残す
-- UI で inactive 表示にする
+- unsubscribe と同時に，その relationship にぶら下がる collection 所属も外す
 
 別案:
 
-- unsubscribe 時に collection 所属を外す
+- collection 所属を別履歴として残し，再 subscription 時に復元できるようにする
 
-現時点では前者の方が，再 subscription 時に user の整理状態を保ちやすそうに見える．
+現時点では前者，つまり current relationship と一緒に collection 所属も外す方が，current model の整合は分かりやすい．
+再 subscription 時に以前の整理状態を復元したいかは，別途 UI / domain 要件として詰める．
 
 ## この時点で ADR にまだ入れないこと
 
@@ -136,5 +149,8 @@ collection 所属については，少なくとも次の 2 案がある．
 - `subscription` は導入しないと model が整合しにくい
 - `subscription` は中間 table より主体 model として扱う方が自然
 - subscribe / unsubscribe の記録は event として分ける案が有力
+- source 登録時には subscription も同時に発生する前提で考える
+- 将来の register は，既存 source の再利用と subscription 作成を許す形が自然
+- unsubscribe では current relationship を外し，履歴は event 側へ残す
 - collection は source ではなく subscription を整理する
 - 詳細 schema と current state / event の最終切り方は，実装直前にもう一段詰める

--- a/docs/design-log/0068-source-subscription-model.md
+++ b/docs/design-log/0068-source-subscription-model.md
@@ -1,0 +1,140 @@
+# ADR-0068 / ADR-0069 に対する source subscription model メモ
+
+## この段階で整理したいこと
+
+- `user は source を subscription し，その subscription を collection で整理する` というモデルを，実装可能な粒度まで下ろす
+- `subscription` を単なる中間 table として扱うか，主体 model として扱うかを見極める
+- subscribe / unsubscribe の履歴をどう保持するかを，ADR ではなく実装設計メモとして残す
+
+## 先に固定したい読み方
+
+- `source`
+  - user 固有資源ではない
+  - 共有可能な収集対象である
+- `subscription`
+  - user がどの source を購読しているかを表す主体である
+  - collection が整理対象としてぶら下がる先は source ではなく subscription である
+- `collection`
+  - user が自分の subscription を整理するための grouping 単位である
+
+## いま気になっていること
+
+- user がいつ source を subscribe したかを記録したい
+- unsubscribe したことも記録したい
+- 将来，再 subscription が起こりうる
+- current state と event history を 1 つの列や 1 行だけで持つと，再購読や履歴照会が窮屈になりやすい
+
+## 現時点の有力案
+
+### 1. subscription は主体 model として持つ
+
+`subscription` は単なる `user_id + source_id` の join ではなく，独立した主体として持つ方がよい．
+
+理由:
+
+- `subscribed_at` のような購読単位属性を自然に持てる
+- collection が source ではなく subscription を参照できる
+- 同じ source を複数 user が購読しても，user ごとの差異を subscription 側へ閉じ込められる
+- 将来，購読単位の表示名，enabled，priority，user 固有設定を持たせやすい
+
+### 2. subscribe / unsubscribe は event として分ける
+
+`subscription` の current state と，subscribe / unsubscribe の履歴は分けて持つ案が有力である．
+
+イメージ:
+
+- `subscriptions`
+  - current state を表す主体
+- `subscription_events`
+  - `subscribed`
+  - `unsubscribed`
+  - 必要なら `resubscribed`
+
+理由:
+
+- 「現在購読中か」を見る query と，「過去に何が起きたか」を見る query の責務を分けられる
+- `unsubscribed_at` 1 本だけより，再 subscription を表現しやすい
+- 履歴保存要件を event 側へ寄せられる
+
+## 現時点の関係案
+
+- `user 1 - n subscription`
+- `source 1 - n subscription`
+- `subscription 1 - n subscription_event`
+- `user 1 - n collection`
+- `collection` は `subscription` を整理する
+
+collection 所属については，少なくとも次の 2 案がある．
+
+### 案 A: subscription は 1 つの collection に属する
+
+- `subscriptions.collection_id`
+
+良い点:
+
+- Explorer 風 UI と相性がよい
+- 実装が単純
+
+気になる点:
+
+- 将来，複数 collection 所属へ広げるときに schema を変えやすい
+
+### 案 B: subscription と collection は関連 table で結ぶ
+
+- `collection_subscriptions`
+
+良い点:
+
+- 複数所属や順序づけに強い
+- 将来拡張しやすい
+
+気になる点:
+
+- 初期実装としては少し重い
+- UI 要件が 1 フォルダ所属前提なら過剰かもしれない
+
+## unsubscribe 時の扱いで未決なこと
+
+### 1. subscription row を再利用するか
+
+案:
+
+- unsubscribe しても `subscription` row 自体は残す
+- 再 subscription 時は同じ `subscription` を active 側へ戻す
+- そのたびに `subscription_event` を追加する
+
+良さそうな点:
+
+- collection 所属や購読単位設定を維持しやすい
+- user から見た「同じ購読対象」に対する連続した履歴を持ちやすい
+
+### 2. unsubscribe 時に collection 所属を残すか
+
+案:
+
+- inactive な subscription でも collection 所属は残す
+- UI で inactive 表示にする
+
+別案:
+
+- unsubscribe 時に collection 所属を外す
+
+現時点では前者の方が，再 subscription 時に user の整理状態を保ちやすそうに見える．
+
+## この時点で ADR にまだ入れないこと
+
+- `subscription` table の最終 schema
+- `subscription_event.kind` の最終語彙
+- collection 所属を 1:1 にするか n:m にするか
+- unsubscribe 時に collection 所属を残すかどうかの最終判断
+- event sourcing 的にどこまで寄せるか
+
+これらは実装判断に近く，まずは design log で持つ．
+
+## 現時点の暫定結論
+
+- `subscription` は導入しないと model が整合しにくい
+- `subscription` は中間 table より主体 model として扱う方が自然
+- subscribe / unsubscribe の記録は event として分ける案が有力
+- collection は source ではなく subscription を整理する
+- 詳細 schema と current state / event の最終切り方は，実装直前にもう一段詰める

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -29,14 +29,7 @@ schema 差分の適用には `psqldef` を使う．
 
 ## data migration
 
-既存データに対する補完や変換が必要な変更では，schema migration だけで完了扱いにしない．
-
-### 要件
-
-- 既存データに何を追加，更新，変換するかを実装前に決める
-- data migration の手順は，schema migration と分けて明示する
-- data migration が必要な変更では，dry-run の確認だけで完了扱いにしない
-- data migration を実行した後の整合条件を確認する
+既存データに対する補完や変換が必要な変更では，schema migration も行う
 
 ### 手順
 
@@ -47,6 +40,7 @@ schema 差分の適用には `psqldef` を使う．
    - SQL あるいは コードでデータ移行処理を実装する
 5. `make db-schema-apply`
 6. 4 で決めた手順で data migration を実行する
+   - 例: `make db-data-migrate DATA_MIGRATION=db/data-migrations/0014-source-subscriptions.sql`
 7. 移行後データを確認する
 
 ### 確認項目

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -4,6 +4,9 @@
 
 `geshi` は podcast，streaming，feed を継続的に収集し，保存し，あとから再生・閲覧・検索できる個人用アーカイブである．
 
+利用者モデルとしては，user が source を subscription し，その subscription を collection で整理する前提を採る．
+source 自体は共有可能な収集対象として扱い，購読関係や整理状態は user ごとに分けて持つ．
+
 ## 構成
 
 ### Web UI frontend
@@ -64,7 +67,7 @@
 ### 閲覧・検索するとき
 
 1. `web ui frontend` が利用者入力を受け取る
-2. `api backend` が `storage` から metadata や検索結果を取得する
+2. `api backend` が user の subscription / collection 文脈と `storage` 上の metadata や検索結果を取得する
 3. 必要に応じて transcript や関連情報をまとめる
 4. `web ui frontend` が一覧，詳細，再生画面として表示する
 
@@ -73,6 +76,13 @@
 1. `cli` が管理コマンドを受け取る
 2. `api backend` や `crawler` に必要な操作を渡す
 3. 結果や状態を `cli` に返す
+
+### 登録・購読するとき
+
+1. `web ui frontend` または `cli` が source 登録要求を受け付ける
+2. `api backend` が対象 source を新規作成するか，既存 source を再利用するか判定する
+3. `api backend` が user に対する subscription を作成する
+4. 必要に応じて collection への所属を更新する
 
 ## 設計上の原則
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -196,6 +196,19 @@ const uncategorizedSources = computed(() =>
     .sort(compareSubscriptionListItems),
 );
 
+const orderedSourcesForBrowse = computed(() => {
+  if (sourceDisplayMode.value === "flat") {
+    return [...sources.value];
+  }
+
+  return [
+    ...uncategorizedSources.value,
+    ...sortedSourceCollections.value.flatMap((collection) =>
+      sourcesForCollection(collection.id),
+    ),
+  ];
+});
+
 const routeHeadline = computed(() => {
   if (routeState.value.kind === "not-found") {
     return "Page not found";
@@ -1400,7 +1413,7 @@ function movePaneFocus(direction: -1 | 1): boolean {
 
 function moveSourceSelection(direction: -1 | 1): boolean {
   const nextSource = selectRelativeItem(
-    sources.value,
+    orderedSourcesForBrowse.value,
     selectedSource.value?.id ?? null,
     direction,
   );

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,6 +19,7 @@ import type {
   PeriodicCrawlSettings,
   PluginGlobalSettingsDetail,
   PreviewSourceResult,
+  SourceCollectionListItem,
   SourceDiscoveryCandidate,
   SourceCollectorPluginListItem,
   SourceCollectorSettingItem,
@@ -26,6 +27,8 @@ import type {
   SourceListItem,
 } from "./source-api.js";
 import {
+  assignSourceToCollection,
+  createSourceCollection,
   createSource,
   discoverSources,
   getContentDetail,
@@ -33,14 +36,17 @@ import {
   getPluginGlobalSettings,
   getSourceCollectorSettings,
   listSourceCollectorPlugins,
+  listSourceCollections,
   listContents,
   listSources,
   observeSource,
   previewSource,
   requestTranscripts,
   retryTranscript,
+  unsubscribeSource,
   updatePeriodicCrawlSettings,
   updatePluginGlobalSettings,
+  updateSourceCollection,
   updateSourceCollectorSettings,
 } from "./source-api.js";
 import {
@@ -61,16 +67,20 @@ type RouteState =
   | { kind: "not-found" };
 
 type BrowsePane = "contents" | "detail" | "sources";
+type SourceDisplayMode = "collections" | "flat";
 
 const contents = ref<ContentListItem[]>([]);
 const contentDetail = ref<ContentDetailItem | null>(null);
 const sourceCollectorPlugins = ref<SourceCollectorPluginListItem[]>([]);
+const sourceCollections = ref<SourceCollectionListItem[]>([]);
 const sources = ref<SourceListItem[]>([]);
+const sourceDisplayMode = ref<SourceDisplayMode>("collections");
 const isCreateFormVisible = ref(false);
 const isDiscovering = ref(false);
 const isLoadingPreviews = ref(false);
 const isSubmitting = ref(false);
 const isObserveSubmitting = ref<string | null>(null);
+const isUnsubscribeSubmitting = ref<string | null>(null);
 const isSourceCrawlSubmitting = ref<string | null>(null);
 const isSettingsSubmitting = ref(false);
 const isSourcesLoading = ref(true);
@@ -129,6 +139,8 @@ const playbackVolume = ref(1);
 const isPlaybackMuted = ref(false);
 const expandedTranscriptIds = ref<Set<string>>(new Set());
 const activeBrowsePane = ref<BrowsePane>("sources");
+const draggedCollectionId = ref<string | null>(null);
+const draggedSourceId = ref<string | null>(null);
 
 const selectedSourceSlug = computed(() => {
   const route = routeState.value;
@@ -167,6 +179,22 @@ const visibleContents = computed(() => {
 
   return [...filteredContents].sort(compareContentListItems);
 });
+
+const sortedSourceCollections = computed(() =>
+  [...sourceCollections.value].sort((left, right) => {
+    if (left.position !== right.position) {
+      return left.position - right.position;
+    }
+
+    return left.createdAt.localeCompare(right.createdAt);
+  }),
+);
+
+const uncategorizedSources = computed(() =>
+  [...sources.value]
+    .filter((source) => source.collectionId === null)
+    .sort(compareSubscriptionListItems),
+);
 
 const routeHeadline = computed(() => {
   if (routeState.value.kind === "not-found") {
@@ -873,12 +901,197 @@ async function refreshSources(): Promise<void> {
   isSourcesLoading.value = true;
 
   try {
-    sources.value = await listSources();
+    const [loadedSources, loadedCollections] = await Promise.all([
+      listSources(),
+      listSourceCollections(),
+    ]);
+    sources.value = loadedSources;
+    sourceCollections.value = loadedCollections;
   } catch (error) {
     errorMessage.value =
       error instanceof Error ? error.message : "Failed to load sources.";
   } finally {
     isSourcesLoading.value = false;
+  }
+}
+
+async function promptCreateCollection(): Promise<void> {
+  const title = window.prompt("Collection name");
+
+  if (title === null) {
+    return;
+  }
+
+  const trimmedTitle = title.trim();
+
+  if (trimmedTitle === "") {
+    errorMessage.value = "Collection name is required.";
+    return;
+  }
+
+  try {
+    const collection = await createSourceCollection({
+      position: sourceCollections.value.length,
+      title: trimmedTitle,
+    });
+    sourceCollections.value = [...sourceCollections.value, collection];
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : "Failed to create collection.";
+  }
+}
+
+async function promptRenameCollection(
+  collection: SourceCollectionListItem,
+): Promise<void> {
+  const title = window.prompt("Rename collection", collection.title);
+
+  if (title === null) {
+    return;
+  }
+
+  const trimmedTitle = title.trim();
+
+  if (trimmedTitle === "") {
+    errorMessage.value = "Collection name is required.";
+    return;
+  }
+
+  try {
+    const updated = await updateSourceCollection(collection.id, {
+      parentCollectionId: collection.parentCollectionId,
+      position: collection.position,
+      title: trimmedTitle,
+    });
+    sourceCollections.value = sourceCollections.value.map((item) =>
+      item.id === updated.id ? updated : item,
+    );
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : "Failed to rename collection.";
+  }
+}
+
+function sourcesForCollection(collectionId: string): SourceListItem[] {
+  return [...sources.value]
+    .filter((source) => source.collectionId === collectionId)
+    .sort(compareSubscriptionListItems);
+}
+
+function beginCollectionDrag(collectionId: string): void {
+  draggedCollectionId.value = collectionId;
+}
+
+function beginSourceDrag(sourceId: string): void {
+  draggedSourceId.value = sourceId;
+}
+
+async function dropCollectionBefore(
+  targetCollection: SourceCollectionListItem,
+): Promise<void> {
+  const sourceCollectionId = draggedCollectionId.value;
+
+  if (
+    sourceCollectionId === null ||
+    sourceCollectionId === targetCollection.id
+  ) {
+    return;
+  }
+
+  const orderedCollections = [...sortedSourceCollections.value];
+  const movingIndex = orderedCollections.findIndex(
+    (collection) => collection.id === sourceCollectionId,
+  );
+  const targetIndex = orderedCollections.findIndex(
+    (collection) => collection.id === targetCollection.id,
+  );
+
+  if (movingIndex === -1 || targetIndex === -1) {
+    return;
+  }
+
+  const [movingCollection] = orderedCollections.splice(movingIndex, 1);
+
+  if (movingCollection === undefined) {
+    return;
+  }
+
+  orderedCollections.splice(targetIndex, 0, movingCollection);
+
+  try {
+    const updates = await Promise.all(
+      orderedCollections.map((collection, index) =>
+        updateSourceCollection(collection.id, {
+          parentCollectionId: collection.parentCollectionId,
+          position: index,
+          title: collection.title,
+        }),
+      ),
+    );
+    sourceCollections.value = updates;
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : "Failed to reorder collections.";
+  } finally {
+    draggedCollectionId.value = null;
+  }
+}
+
+async function dropSourceIntoCollection(
+  collectionId: string | null,
+  position: number,
+): Promise<void> {
+  const sourceId = draggedSourceId.value;
+
+  if (sourceId === null) {
+    return;
+  }
+
+  try {
+    const updatedSource = await assignSourceToCollection(sourceId, {
+      collectionId,
+      position,
+    });
+    sources.value = sources.value.map((source) =>
+      source.id === updatedSource.id ? updatedSource : source,
+    );
+    await refreshSources();
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error
+        ? error.message
+        : "Failed to move source subscription.";
+  } finally {
+    draggedSourceId.value = null;
+  }
+}
+
+async function unsubscribeSelectedSource(): Promise<void> {
+  if (selectedSource.value === null) {
+    return;
+  }
+
+  const confirmed = window.confirm(
+    `Unsubscribe from ${selectedSource.value.title ?? selectedSource.value.slug}?`,
+  );
+
+  if (!confirmed) {
+    return;
+  }
+
+  isUnsubscribeSubmitting.value = selectedSource.value.subscriptionId;
+
+  try {
+    await unsubscribeSource(selectedSource.value.subscriptionId);
+    sourceCrawlErrorMessage.value = null;
+    isSourceSettingsExpanded.value = false;
+    navigateTo("/browse");
+    await Promise.all([refreshSources(), refreshContents()]);
+  } catch (error) {
+    sourceCrawlErrorMessage.value =
+      error instanceof Error ? error.message : "Failed to unsubscribe source.";
+  } finally {
+    isUnsubscribeSubmitting.value = null;
   }
 }
 
@@ -1172,8 +1385,9 @@ function movePaneFocus(direction: -1 | 1): boolean {
   }
 
   const contentToOpen =
-    visibleContents.value.find((content) => content.id === selectedContentId.value) ??
-    visibleContents.value[0];
+    visibleContents.value.find(
+      (content) => content.id === selectedContentId.value,
+    ) ?? visibleContents.value[0];
 
   if (contentToOpen === undefined) {
     return false;
@@ -1281,6 +1495,17 @@ function selectRelativeItem<Item extends { id: string }>(
       : Math.max(0, Math.min(items.length - 1, currentIndex + direction));
 
   return items[nextIndex] ?? null;
+}
+
+function compareSubscriptionListItems(
+  left: SourceListItem,
+  right: SourceListItem,
+): number {
+  if (left.subscriptionPosition !== right.subscriptionPosition) {
+    return left.subscriptionPosition - right.subscriptionPosition;
+  }
+
+  return right.createdAt.localeCompare(left.createdAt);
 }
 
 function shouldIgnoreKeyboardNavigationTarget(
@@ -1694,8 +1919,8 @@ function normalizeCollectorSettingFormValue(
       <section v-if="isCreateFormVisible" class="create-shell">
         <div class="create-shell-header">
           <div>
-            <p class="eyebrow">Register source</p>
-            <h2>Add source</h2>
+            <p class="eyebrow">Subscribe Source</p>
+            <h2>Add subscription</h2>
           </div>
           <button class="ghost-button" type="button" @click="closeCreateForm">
             Close
@@ -1737,7 +1962,7 @@ function normalizeCollectorSettingFormValue(
           <div class="create-grid-wide settings-shell-header">
             <div>
               <p class="eyebrow">Detected Sources</p>
-              <h3>Select sources to register</h3>
+              <h3>Select sources to subscribe</h3>
             </div>
             <div class="actions">
               <button
@@ -1749,7 +1974,7 @@ function normalizeCollectorSettingFormValue(
                 @click="submitSource"
               >
                 {{
-                  isSubmitting ? "Registering..." : "Register selected sources"
+                  isSubmitting ? "Subscribing..." : "Subscribe selected sources"
                 }}
               </button>
             </div>
@@ -1830,12 +2055,37 @@ function normalizeCollectorSettingFormValue(
         >
           <div class="pane-header">
             <div class="pane-heading">
-              <p class="eyebrow">Feeds</p>
-              <h2>Sources</h2>
-              <p class="pane-caption">Registered feeds and collectors</p>
+              <p class="eyebrow">Subscriptions</p>
+              <h2>Subscribed sources</h2>
+              <p class="pane-caption">Sources you subscribed to and collect</p>
             </div>
             <span class="pane-count">{{ sources.length }}</span>
             <div class="pane-actions">
+              <button
+                type="button"
+                class="ghost-button menu-toggle-button"
+                :class="{ active: sourceDisplayMode === 'collections' }"
+                @click="sourceDisplayMode = 'collections'"
+              >
+                Folders
+              </button>
+              <button
+                type="button"
+                class="ghost-button menu-toggle-button"
+                :class="{ active: sourceDisplayMode === 'flat' }"
+                @click="sourceDisplayMode = 'flat'"
+              >
+                Flat
+              </button>
+              <button
+                type="button"
+                class="ghost-button menu-toggle-button"
+                aria-label="Add collection"
+                title="Add collection"
+                @click="promptCreateCollection"
+              >
+                Folder
+              </button>
               <button
                 type="button"
                 class="ghost-button menu-toggle-button pane-add-button"
@@ -1858,6 +2108,163 @@ function normalizeCollectorSettingFormValue(
 
           <div v-if="isSourcesLoading" class="empty-state">
             Loading sources...
+          </div>
+
+          <div
+            v-else-if="sourceDisplayMode === 'collections'"
+            class="collection-browser"
+          >
+            <section
+              class="collection-group"
+              @dragover.prevent
+              @drop.prevent="void dropSourceIntoCollection(null, 0)"
+            >
+              <div class="collection-header">
+                <div>
+                  <p class="eyebrow">Unsorted</p>
+                  <h3>Uncategorized</h3>
+                </div>
+                <span class="pane-count">{{
+                  uncategorizedSources.length
+                }}</span>
+              </div>
+              <ul
+                v-if="uncategorizedSources.length > 0"
+                class="source-list collection-source-list"
+              >
+                <li
+                  v-for="source in uncategorizedSources"
+                  :key="source.subscriptionId"
+                >
+                  <button
+                    type="button"
+                    class="source-row"
+                    :class="{ selected: isSourceSelected(source) }"
+                    draggable="true"
+                    @click="openFeed(source)"
+                    @dragstart="beginSourceDrag(source.id)"
+                  >
+                    <span class="source-row-head">
+                      <span class="source-row-title">
+                        {{ source.title ?? source.slug }}
+                      </span>
+                      <span
+                        class="source-row-status"
+                        :class="{
+                          active: source.periodicCrawlEnabled,
+                          idle: !source.periodicCrawlEnabled,
+                        }"
+                      >
+                        {{
+                          source.periodicCrawlEnabled
+                            ? `Auto ${source.periodicCrawlIntervalMinutes}m`
+                            : "Manual"
+                        }}
+                      </span>
+                    </span>
+                    <span class="source-row-meta-line">
+                      <span class="source-row-domain">
+                        {{ sourceDomainLabel(source.url) }}
+                      </span>
+                      <span class="source-row-meta"
+                        >{{ source.kind }} · {{ source.slug }}</span
+                      >
+                    </span>
+                  </button>
+                </li>
+              </ul>
+              <div v-else class="empty-state compact-empty-state">
+                No uncategorized subscriptions.
+              </div>
+            </section>
+
+            <section
+              v-for="collection in sortedSourceCollections"
+              :key="collection.id"
+              class="collection-group"
+              draggable="true"
+              @dragstart="beginCollectionDrag(collection.id)"
+              @dragover.prevent
+              @drop.prevent="void dropCollectionBefore(collection)"
+            >
+              <div
+                class="collection-header"
+                @dragover.prevent
+                @drop.prevent="
+                  void dropSourceIntoCollection(
+                    collection.id,
+                    sourcesForCollection(collection.id).length,
+                  )
+                "
+              >
+                <div>
+                  <p class="eyebrow">Folder</p>
+                  <h3>{{ collection.title }}</h3>
+                </div>
+                <div class="collection-actions">
+                  <span class="pane-count">{{ collection.sourceCount }}</span>
+                  <button
+                    type="button"
+                    class="ghost-button menu-toggle-button"
+                    @click="void promptRenameCollection(collection)"
+                  >
+                    Rename
+                  </button>
+                </div>
+              </div>
+              <ul
+                v-if="sourcesForCollection(collection.id).length > 0"
+                class="source-list collection-source-list"
+              >
+                <li
+                  v-for="(source, index) in sourcesForCollection(collection.id)"
+                  :key="source.subscriptionId"
+                  @dragover.prevent
+                  @drop.prevent="
+                    void dropSourceIntoCollection(collection.id, index)
+                  "
+                >
+                  <button
+                    type="button"
+                    class="source-row"
+                    :class="{ selected: isSourceSelected(source) }"
+                    draggable="true"
+                    @click="openFeed(source)"
+                    @dragstart="beginSourceDrag(source.id)"
+                  >
+                    <span class="source-row-head">
+                      <span class="source-row-title">
+                        {{ source.title ?? source.slug }}
+                      </span>
+                      <span
+                        class="source-row-status"
+                        :class="{
+                          active: source.periodicCrawlEnabled,
+                          idle: !source.periodicCrawlEnabled,
+                        }"
+                      >
+                        {{
+                          source.periodicCrawlEnabled
+                            ? `Auto ${source.periodicCrawlIntervalMinutes}m`
+                            : "Manual"
+                        }}
+                      </span>
+                    </span>
+                    <span class="source-row-meta-line">
+                      <span class="source-row-domain">
+                        {{ sourceDomainLabel(source.url) }}
+                      </span>
+                      <span class="source-row-meta"
+                        >{{ source.kind }} · {{ source.slug }}</span
+                      >
+                    </span>
+                  </button>
+                </li>
+              </ul>
+              <div v-else class="empty-state compact-empty-state">
+                Drop a subscription here.
+              </div>
+            </section>
           </div>
 
           <ul v-else-if="sources.length > 0" class="source-list">
@@ -1902,7 +2309,7 @@ function normalizeCollectorSettingFormValue(
           </ul>
 
           <div v-else class="empty-state">
-            No sources registered yet. Add a feed to get started.
+            No subscriptions yet. Add a source to get started.
           </div>
         </aside>
 
@@ -1917,7 +2324,7 @@ function normalizeCollectorSettingFormValue(
               <p class="pane-caption">
                 {{
                   selectedSource === null
-                    ? "Across every registered source"
+                    ? "Across every subscribed source"
                     : sourceDomainLabel(selectedSource.url)
                 }}
               </p>
@@ -2052,6 +2459,20 @@ function normalizeCollectorSettingFormValue(
                     isSourceCrawlSubmitting === selectedSource.id
                       ? "Saving..."
                       : "Save source settings"
+                  }}
+                </button>
+                <button
+                  type="button"
+                  class="ghost-button"
+                  :disabled="
+                    isUnsubscribeSubmitting === selectedSource.subscriptionId
+                  "
+                  @click="unsubscribeSelectedSource"
+                >
+                  {{
+                    isUnsubscribeSubmitting === selectedSource.subscriptionId
+                      ? "Unsubscribing..."
+                      : "Unsubscribe"
                   }}
                 </button>
               </div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -378,6 +378,20 @@ function handleGlobalKeydown(event: KeyboardEvent): void {
 
       return;
     }
+    case "o": {
+      if (triggerOriginalPageShortcut()) {
+        event.preventDefault();
+      }
+
+      return;
+    }
+    case "p": {
+      if (triggerPlaybackShortcut()) {
+        event.preventDefault();
+      }
+
+      return;
+    }
     default: {
       return;
     }
@@ -1218,6 +1232,36 @@ function moveDetailSelection(direction: -1 | 1): boolean {
   return true;
 }
 
+function triggerOriginalPageShortcut(): boolean {
+  if (activeBrowsePane.value !== "detail" || contentDetail.value === null) {
+    return false;
+  }
+
+  const originalPageUrl = detailOriginalPageUrl(contentDetail.value);
+
+  if (originalPageUrl === null) {
+    return false;
+  }
+
+  openExternalUrl(originalPageUrl);
+  return true;
+}
+
+function triggerPlaybackShortcut(): boolean {
+  if (activeBrowsePane.value !== "detail" || contentDetail.value === null) {
+    return false;
+  }
+
+  const asset = detailHeaderAudioAsset.value;
+
+  if (asset === null) {
+    return false;
+  }
+
+  startPlayback(contentDetail.value, asset);
+  return true;
+}
+
 function selectRelativeItem<Item extends { id: string }>(
   items: Item[],
   selectedId: string | null,
@@ -1267,6 +1311,10 @@ function scrollSelectedRowIntoView(): void {
   selectedRow?.scrollIntoView({
     block: "nearest",
   });
+}
+
+function openExternalUrl(url: string): void {
+  window.open(url, "_blank", "noopener,noreferrer");
 }
 
 function normalizeRoute(pathname: string): RouteState {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -68,6 +68,7 @@ type RouteState =
 
 type BrowsePane = "contents" | "detail" | "sources";
 type SourceDisplayMode = "collections" | "flat";
+type CollectionDialogMode = "create" | "rename";
 
 const contents = ref<ContentListItem[]>([]);
 const contentDetail = ref<ContentDetailItem | null>(null);
@@ -75,7 +76,11 @@ const sourceCollectorPlugins = ref<SourceCollectorPluginListItem[]>([]);
 const sourceCollections = ref<SourceCollectionListItem[]>([]);
 const sources = ref<SourceListItem[]>([]);
 const sourceDisplayMode = ref<SourceDisplayMode>("collections");
+const collectionDialogMode = ref<CollectionDialogMode | null>(null);
+const collectionDialogTarget = ref<SourceCollectionListItem | null>(null);
+const collectionDialogTitle = ref("");
 const isCreateFormVisible = ref(false);
+const isCollectionDialogSubmitting = ref(false);
 const isDiscovering = ref(false);
 const isLoadingPreviews = ref(false);
 const isSubmitting = ref(false);
@@ -87,6 +92,7 @@ const isSourcesLoading = ref(true);
 const isContentsLoading = ref(true);
 const isContentActionsExpanded = ref(false);
 const isDetailLoading = ref(false);
+const collapsedCollectionIds = ref<Set<string>>(new Set());
 const expandedAssetMenuId = ref<string | null>(null);
 const isTranscriptSubmitting = ref<string | null>(null);
 const isSettingsLoading = ref(true);
@@ -128,6 +134,9 @@ const pluginGlobalSettings = ref<
 >([]);
 const pluginGlobalItemsForm = ref<Record<string, Record<string, unknown>>>({});
 const theme = ref<"light" | "dark">("light");
+const collectionDialogInput = useTemplateRef<HTMLInputElement>(
+  "collectionDialogInput",
+);
 const audioPlayer = useTemplateRef<HTMLAudioElement>("audioPlayer");
 const playback = ref<PlaybackState | null>(null);
 const playbackCurrentTime = ref(0);
@@ -209,6 +218,11 @@ const orderedSourcesForBrowse = computed(() => {
   ];
 });
 
+const isAllSourcesSelected = computed(
+  () =>
+    routeState.value.kind === "browse-index" && selectedSource.value === null,
+);
+
 const routeHeadline = computed(() => {
   if (routeState.value.kind === "not-found") {
     return "Page not found";
@@ -278,6 +292,10 @@ watch(theme, (currentTheme) => {
   window.localStorage.setItem("geshi-theme", currentTheme);
 });
 
+watch(sourceDisplayMode, (currentMode) => {
+  window.localStorage.setItem("geshi-source-display-mode", currentMode);
+});
+
 watch(playbackVolume, (nextVolume) => {
   const element = audioPlayer.value;
 
@@ -341,6 +359,7 @@ onMounted(async () => {
   }
 
   theme.value = readInitialTheme();
+  sourceDisplayMode.value = readInitialSourceDisplayMode();
 
   window.addEventListener("popstate", syncRouteFromLocation);
   window.addEventListener("keydown", handleGlobalKeydown);
@@ -382,6 +401,7 @@ function handleGlobalKeydown(event: KeyboardEvent): void {
     event.altKey ||
     event.ctrlKey ||
     event.metaKey ||
+    collectionDialogMode.value !== null ||
     isCreateFormVisible.value ||
     routeState.value.kind === "settings" ||
     routeState.value.kind === "not-found" ||
@@ -468,8 +488,33 @@ function closeCreateForm(): void {
   selectedDiscoveryKeys.value = [];
 }
 
-function toggleTheme(): void {
-  theme.value = theme.value === "dark" ? "light" : "dark";
+async function openCreateCollectionDialog(): Promise<void> {
+  collectionDialogMode.value = "create";
+  collectionDialogTarget.value = null;
+  collectionDialogTitle.value = "";
+  errorMessage.value = null;
+  await nextTick();
+  collectionDialogInput.value?.focus();
+  collectionDialogInput.value?.select();
+}
+
+async function openRenameCollectionDialog(
+  collection: SourceCollectionListItem,
+): Promise<void> {
+  collectionDialogMode.value = "rename";
+  collectionDialogTarget.value = collection;
+  collectionDialogTitle.value = collection.title;
+  errorMessage.value = null;
+  await nextTick();
+  collectionDialogInput.value?.focus();
+  collectionDialogInput.value?.select();
+}
+
+function closeCollectionDialog(): void {
+  collectionDialogMode.value = null;
+  collectionDialogTarget.value = null;
+  collectionDialogTitle.value = "";
+  isCollectionDialogSubmitting.value = false;
 }
 
 function toggleSourceSettings(): void {
@@ -928,60 +973,52 @@ async function refreshSources(): Promise<void> {
   }
 }
 
-async function promptCreateCollection(): Promise<void> {
-  const title = window.prompt("Collection name");
-
-  if (title === null) {
-    return;
-  }
-
-  const trimmedTitle = title.trim();
+async function submitCollectionDialog(): Promise<void> {
+  const trimmedTitle = collectionDialogTitle.value.trim();
 
   if (trimmedTitle === "") {
     errorMessage.value = "Collection name is required.";
     return;
   }
 
-  try {
-    const collection = await createSourceCollection({
-      position: sourceCollections.value.length,
-      title: trimmedTitle,
-    });
-    sourceCollections.value = [...sourceCollections.value, collection];
-  } catch (error) {
-    errorMessage.value =
-      error instanceof Error ? error.message : "Failed to create collection.";
-  }
-}
+  const mode = collectionDialogMode.value;
+  const target = collectionDialogTarget.value;
 
-async function promptRenameCollection(
-  collection: SourceCollectionListItem,
-): Promise<void> {
-  const title = window.prompt("Rename collection", collection.title);
-
-  if (title === null) {
+  if (mode === null) {
     return;
   }
 
-  const trimmedTitle = title.trim();
-
-  if (trimmedTitle === "") {
-    errorMessage.value = "Collection name is required.";
-    return;
-  }
+  isCollectionDialogSubmitting.value = true;
 
   try {
-    const updated = await updateSourceCollection(collection.id, {
-      parentCollectionId: collection.parentCollectionId,
-      position: collection.position,
-      title: trimmedTitle,
-    });
-    sourceCollections.value = sourceCollections.value.map((item) =>
-      item.id === updated.id ? updated : item,
-    );
+    if (mode === "create") {
+      const collection = await createSourceCollection({
+        position: sourceCollections.value.length,
+        title: trimmedTitle,
+      });
+      sourceCollections.value = [...sourceCollections.value, collection];
+      sourceDisplayMode.value = "collections";
+    } else if (target !== null) {
+      const updated = await updateSourceCollection(target.id, {
+        parentCollectionId: target.parentCollectionId,
+        position: target.position,
+        title: trimmedTitle,
+      });
+      sourceCollections.value = sourceCollections.value.map((item) =>
+        item.id === updated.id ? updated : item,
+      );
+    }
+
+    closeCollectionDialog();
   } catch (error) {
     errorMessage.value =
-      error instanceof Error ? error.message : "Failed to rename collection.";
+      error instanceof Error
+        ? error.message
+        : mode === "create"
+          ? "Failed to create collection."
+          : "Failed to rename collection.";
+  } finally {
+    isCollectionDialogSubmitting.value = false;
   }
 }
 
@@ -997,6 +1034,22 @@ function beginCollectionDrag(collectionId: string): void {
 
 function beginSourceDrag(sourceId: string): void {
   draggedSourceId.value = sourceId;
+}
+
+function isCollectionExpanded(collectionId: string): boolean {
+  return !collapsedCollectionIds.value.has(collectionId);
+}
+
+function toggleCollectionExpanded(collectionId: string): void {
+  const next = new Set(collapsedCollectionIds.value);
+
+  if (next.has(collectionId)) {
+    next.delete(collectionId);
+  } else {
+    next.add(collectionId);
+  }
+
+  collapsedCollectionIds.value = next;
 }
 
 async function dropCollectionBefore(
@@ -1048,6 +1101,20 @@ async function dropCollectionBefore(
   } finally {
     draggedCollectionId.value = null;
   }
+}
+
+async function handleCollectionGroupDrop(
+  targetCollection: SourceCollectionListItem,
+): Promise<void> {
+  if (draggedSourceId.value !== null) {
+    await dropSourceIntoCollection(
+      targetCollection.id,
+      sourcesForCollection(targetCollection.id).length,
+    );
+    return;
+  }
+
+  await dropCollectionBefore(targetCollection);
 }
 
 async function dropSourceIntoCollection(
@@ -1346,6 +1413,10 @@ function openFeed(source: SourceListItem): void {
   navigateTo(`/browse/feed/${encodeURIComponent(source.slug)}`);
 }
 
+function openAllEntries(): void {
+  navigateTo("/browse");
+}
+
 function openEntry(content: ContentListItem): void {
   navigateTo(`/browse/entry/${content.id}`);
 }
@@ -1412,17 +1483,39 @@ function movePaneFocus(direction: -1 | 1): boolean {
 }
 
 function moveSourceSelection(direction: -1 | 1): boolean {
-  const nextSource = selectRelativeItem(
-    orderedSourcesForBrowse.value,
-    selectedSource.value?.id ?? null,
-    direction,
-  );
+  const orderedItems = orderedSourcesForBrowse.value;
 
-  if (nextSource === null) {
+  if (orderedItems.length === 0) {
     return false;
   }
 
+  const currentIndex = selectedSource.value
+    ? orderedItems.findIndex((source) => source.id === selectedSource.value?.id)
+    : -1;
+  const virtualIndex = isAllSourcesSelected.value ? -1 : currentIndex;
+  const nextIndex =
+    virtualIndex === -1
+      ? direction > 0
+        ? 0
+        : -1
+      : Math.max(
+          -1,
+          Math.min(orderedItems.length - 1, virtualIndex + direction),
+        );
+
   activeBrowsePane.value = "sources";
+
+  if (nextIndex === -1) {
+    openAllEntries();
+    return true;
+  }
+
+  const nextSource = orderedItems[nextIndex];
+
+  if (nextSource === undefined) {
+    return false;
+  }
+
   openFeed(nextSource);
   return true;
 }
@@ -1525,6 +1618,10 @@ function shouldIgnoreKeyboardNavigationTarget(
   target: EventTarget | null,
 ): boolean {
   if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (target.closest(".source-row, .content-row") !== null) {
     return false;
   }
 
@@ -1640,6 +1737,16 @@ function readInitialTheme(): "light" | "dark" {
   const initialTheme = "dark";
   document.documentElement.dataset.theme = initialTheme;
   return initialTheme;
+}
+
+function readInitialSourceDisplayMode(): SourceDisplayMode {
+  const storedMode = window.localStorage.getItem("geshi-source-display-mode");
+
+  if (storedMode === "collections" || storedMode === "flat") {
+    return storedMode;
+  }
+
+  return "collections";
 }
 
 function sourceDomainLabel(sourceUrl: string): string {
@@ -1800,9 +1907,6 @@ function normalizeCollectorSettingFormValue(
             Settings
           </button>
         </nav>
-        <button class="ghost-button" type="button" @click="toggleTheme">
-          {{ theme === "dark" ? "Light" : "Dark" }}
-        </button>
       </div>
     </header>
 
@@ -1812,6 +1916,31 @@ function normalizeCollectorSettingFormValue(
     </p>
 
     <section v-if="routeState.kind === 'settings'" class="settings-shell">
+      <div class="settings-shell-header">
+        <div>
+          <p class="eyebrow">Interface</p>
+          <h2>Appearance and Browse Layout</h2>
+        </div>
+      </div>
+
+      <div class="settings-grid">
+        <label>
+          <span>Theme</span>
+          <select v-model="theme">
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+          </select>
+        </label>
+
+        <label>
+          <span>Source Display Mode</span>
+          <select v-model="sourceDisplayMode">
+            <option value="collections">Folders</option>
+            <option value="flat">Flat</option>
+          </select>
+        </label>
+      </div>
+
       <div class="settings-shell-header">
         <div>
           <p class="eyebrow">Operations</p>
@@ -1929,6 +2058,81 @@ function normalizeCollectorSettingFormValue(
     </section>
 
     <template v-else>
+      <section
+        v-if="collectionDialogMode !== null"
+        class="collection-dialog-backdrop"
+        @click.self="closeCollectionDialog"
+      >
+        <div class="collection-dialog" role="dialog" aria-modal="true">
+          <div class="create-shell-header">
+            <div>
+              <p class="eyebrow">Collection</p>
+              <h2>
+                {{
+                  collectionDialogMode === "create"
+                    ? "Create collection"
+                    : "Rename collection"
+                }}
+              </h2>
+            </div>
+            <button
+              class="ghost-button"
+              type="button"
+              @click="closeCollectionDialog"
+            >
+              Close
+            </button>
+          </div>
+
+          <form
+            class="create-grid"
+            @submit.prevent="void submitCollectionDialog()"
+          >
+            <label class="create-grid-wide">
+              <span>Name</span>
+              <input
+                ref="collectionDialogInput"
+                v-model="collectionDialogTitle"
+                :disabled="isCollectionDialogSubmitting"
+                type="text"
+                maxlength="120"
+                placeholder="Work"
+              />
+            </label>
+
+            <p v-if="errorMessage" class="feedback error create-grid-wide">
+              {{ errorMessage }}
+            </p>
+
+            <div class="actions create-grid-wide">
+              <button
+                type="submit"
+                class="primary-button"
+                :disabled="isCollectionDialogSubmitting"
+              >
+                {{
+                  isCollectionDialogSubmitting
+                    ? collectionDialogMode === "create"
+                      ? "Creating..."
+                      : "Saving..."
+                    : collectionDialogMode === "create"
+                      ? "Create collection"
+                      : "Save changes"
+                }}
+              </button>
+              <button
+                type="button"
+                class="secondary-button"
+                :disabled="isCollectionDialogSubmitting"
+                @click="closeCollectionDialog"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
       <section v-if="isCreateFormVisible" class="create-shell">
         <div class="create-shell-header">
           <div>
@@ -2077,25 +2281,9 @@ function normalizeCollectorSettingFormValue(
               <button
                 type="button"
                 class="ghost-button menu-toggle-button"
-                :class="{ active: sourceDisplayMode === 'collections' }"
-                @click="sourceDisplayMode = 'collections'"
-              >
-                Folders
-              </button>
-              <button
-                type="button"
-                class="ghost-button menu-toggle-button"
-                :class="{ active: sourceDisplayMode === 'flat' }"
-                @click="sourceDisplayMode = 'flat'"
-              >
-                Flat
-              </button>
-              <button
-                type="button"
-                class="ghost-button menu-toggle-button"
                 aria-label="Add collection"
                 title="Add collection"
-                @click="promptCreateCollection"
+                @click="openCreateCollectionDialog"
               >
                 Folder
               </button>
@@ -2123,164 +2311,175 @@ function normalizeCollectorSettingFormValue(
             Loading sources...
           </div>
 
-          <div
+          <ul
             v-else-if="sourceDisplayMode === 'collections'"
-            class="collection-browser"
+            class="source-list collection-tree"
+            @dragover.prevent
+            @drop.prevent="void dropSourceIntoCollection(null, 0)"
           >
-            <section
-              class="collection-group"
-              @dragover.prevent
-              @drop.prevent="void dropSourceIntoCollection(null, 0)"
-            >
-              <div class="collection-header">
-                <div>
-                  <p class="eyebrow">Unsorted</p>
-                  <h3>Uncategorized</h3>
-                </div>
-                <span class="pane-count">{{
-                  uncategorizedSources.length
-                }}</span>
-              </div>
-              <ul
-                v-if="uncategorizedSources.length > 0"
-                class="source-list collection-source-list"
+            <li>
+              <button
+                type="button"
+                class="source-row"
+                :class="{ selected: isAllSourcesSelected }"
+                @click="openAllEntries"
               >
-                <li
-                  v-for="source in uncategorizedSources"
-                  :key="source.subscriptionId"
-                >
-                  <button
-                    type="button"
-                    class="source-row"
-                    :class="{ selected: isSourceSelected(source) }"
-                    draggable="true"
-                    @click="openFeed(source)"
-                    @dragstart="beginSourceDrag(source.id)"
-                  >
-                    <span class="source-row-head">
-                      <span class="source-row-title">
-                        {{ source.title ?? source.slug }}
-                      </span>
-                      <span
-                        class="source-row-status"
-                        :class="{
-                          active: source.periodicCrawlEnabled,
-                          idle: !source.periodicCrawlEnabled,
-                        }"
-                      >
-                        {{
-                          source.periodicCrawlEnabled
-                            ? `Auto ${source.periodicCrawlIntervalMinutes}m`
-                            : "Manual"
-                        }}
-                      </span>
-                    </span>
-                    <span class="source-row-meta-line">
-                      <span class="source-row-domain">
-                        {{ sourceDomainLabel(source.url) }}
-                      </span>
-                      <span class="source-row-meta"
-                        >{{ source.kind }} · {{ source.slug }}</span
-                      >
-                    </span>
-                  </button>
-                </li>
-              </ul>
-              <div v-else class="empty-state compact-empty-state">
-                No uncategorized subscriptions.
-              </div>
-            </section>
+                <span class="source-row-main">
+                  <span class="source-row-icon" aria-hidden="true">
+                    <svg class="source-row-icon-svg" viewBox="0 0 24 24">
+                      <path
+                        d="M4 6h16M4 12h16M4 18h16"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="square"
+                        stroke-width="1.8"
+                      />
+                    </svg>
+                  </span>
+                  <span class="source-row-title">All</span>
+                </span>
+              </button>
+            </li>
+            <li
+              v-for="source in uncategorizedSources"
+              :key="source.subscriptionId"
+            >
+              <button
+                type="button"
+                class="source-row"
+                :class="{ selected: isSourceSelected(source) }"
+                draggable="true"
+                @click="openFeed(source)"
+                @dragstart="beginSourceDrag(source.id)"
+              >
+                <span class="source-row-main">
+                  <span class="source-row-icon" aria-hidden="true">
+                    <svg class="source-row-icon-svg" viewBox="0 0 24 24">
+                      <path
+                        d="M6 17a1.5 1.5 0 1 1 0 .01M5 10a9 9 0 0 1 9 9M5 5a14 14 0 0 1 14 14"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="square"
+                        stroke-width="1.8"
+                      />
+                    </svg>
+                  </span>
+                  <span class="source-row-title">
+                    {{ source.title ?? source.slug }}
+                  </span>
+                </span>
+              </button>
+            </li>
 
-            <section
+            <template
               v-for="collection in sortedSourceCollections"
               :key="collection.id"
-              class="collection-group"
-              draggable="true"
-              @dragstart="beginCollectionDrag(collection.id)"
-              @dragover.prevent
-              @drop.prevent="void dropCollectionBefore(collection)"
             >
-              <div
-                class="collection-header"
+              <li
+                class="collection-tree-folder"
+                draggable="true"
+                @dragstart="beginCollectionDrag(collection.id)"
                 @dragover.prevent
-                @drop.prevent="
-                  void dropSourceIntoCollection(
-                    collection.id,
-                    sourcesForCollection(collection.id).length,
-                  )
-                "
+                @drop.prevent="void handleCollectionGroupDrop(collection)"
               >
-                <div>
-                  <p class="eyebrow">Folder</p>
-                  <h3>{{ collection.title }}</h3>
-                </div>
-                <div class="collection-actions">
-                  <span class="pane-count">{{ collection.sourceCount }}</span>
-                  <button
-                    type="button"
-                    class="ghost-button menu-toggle-button"
-                    @click="void promptRenameCollection(collection)"
-                  >
-                    Rename
-                  </button>
-                </div>
-              </div>
-              <ul
-                v-if="sourcesForCollection(collection.id).length > 0"
-                class="source-list collection-source-list"
-              >
-                <li
-                  v-for="(source, index) in sourcesForCollection(collection.id)"
-                  :key="source.subscriptionId"
+                <div
+                  class="source-row collection-row"
                   @dragover.prevent
                   @drop.prevent="
-                    void dropSourceIntoCollection(collection.id, index)
+                    void dropSourceIntoCollection(
+                      collection.id,
+                      sourcesForCollection(collection.id).length,
+                    )
                   "
                 >
-                  <button
-                    type="button"
-                    class="source-row"
-                    :class="{ selected: isSourceSelected(source) }"
-                    draggable="true"
-                    @click="openFeed(source)"
-                    @dragstart="beginSourceDrag(source.id)"
-                  >
-                    <span class="source-row-head">
-                      <span class="source-row-title">
-                        {{ source.title ?? source.slug }}
-                      </span>
-                      <span
-                        class="source-row-status"
-                        :class="{
-                          active: source.periodicCrawlEnabled,
-                          idle: !source.periodicCrawlEnabled,
-                        }"
+                  <div class="collection-row-main">
+                    <button
+                      type="button"
+                      class="collection-toggle"
+                      :aria-expanded="isCollectionExpanded(collection.id)"
+                      @click.stop="toggleCollectionExpanded(collection.id)"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="collection-toggle-icon"
+                        viewBox="0 0 24 24"
                       >
-                        {{
-                          source.periodicCrawlEnabled
-                            ? `Auto ${source.periodicCrawlIntervalMinutes}m`
-                            : "Manual"
-                        }}
-                      </span>
+                        <path
+                          d="M9 6l6 6-6 6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="square"
+                          stroke-width="1.8"
+                        />
+                      </svg>
+                    </button>
+                    <span class="source-row-title">{{ collection.title }}</span>
+                  </div>
+                </div>
+              </li>
+              <li
+                v-for="(source, index) in sourcesForCollection(collection.id)"
+                v-show="isCollectionExpanded(collection.id)"
+                :key="source.subscriptionId"
+                class="collection-tree-child"
+                @dragover.prevent
+                @drop.prevent="
+                  void dropSourceIntoCollection(collection.id, index)
+                "
+              >
+                <button
+                  type="button"
+                  class="source-row source-row-child"
+                  :class="{ selected: isSourceSelected(source) }"
+                  draggable="true"
+                  @click="openFeed(source)"
+                  @dragstart="beginSourceDrag(source.id)"
+                >
+                  <span class="source-row-main">
+                    <span class="source-row-icon" aria-hidden="true">
+                      <svg class="source-row-icon-svg" viewBox="0 0 24 24">
+                        <path
+                          d="M6 17a1.5 1.5 0 1 1 0 .01M5 10a9 9 0 0 1 9 9M5 5a14 14 0 0 1 14 14"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="square"
+                          stroke-width="1.8"
+                        />
+                      </svg>
                     </span>
-                    <span class="source-row-meta-line">
-                      <span class="source-row-domain">
-                        {{ sourceDomainLabel(source.url) }}
-                      </span>
-                      <span class="source-row-meta"
-                        >{{ source.kind }} · {{ source.slug }}</span
-                      >
+                    <span class="source-row-title">
+                      {{ source.title ?? source.slug }}
                     </span>
-                  </button>
-                </li>
-              </ul>
-              <div v-else class="empty-state compact-empty-state">
-                Drop a subscription here.
-              </div>
-            </section>
-          </div>
+                  </span>
+                </button>
+              </li>
+            </template>
+          </ul>
 
           <ul v-else-if="sources.length > 0" class="source-list">
+            <li>
+              <button
+                type="button"
+                class="source-row"
+                :class="{ selected: isAllSourcesSelected }"
+                @click="openAllEntries"
+              >
+                <span class="source-row-main">
+                  <span class="source-row-icon" aria-hidden="true">
+                    <svg class="source-row-icon-svg" viewBox="0 0 24 24">
+                      <path
+                        d="M4 6h16M4 12h16M4 18h16"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="square"
+                        stroke-width="1.8"
+                      />
+                    </svg>
+                  </span>
+                  <span class="source-row-title">All</span>
+                </span>
+              </button>
+            </li>
             <li v-for="source in sources" :key="source.id">
               <button
                 type="button"
@@ -2288,34 +2487,21 @@ function normalizeCollectorSettingFormValue(
                 :class="{ selected: isSourceSelected(source) }"
                 @click="openFeed(source)"
               >
-                <span class="source-row-head">
+                <span class="source-row-main">
+                  <span class="source-row-icon" aria-hidden="true">
+                    <svg class="source-row-icon-svg" viewBox="0 0 24 24">
+                      <path
+                        d="M6 17a1.5 1.5 0 1 1 0 .01M5 10a9 9 0 0 1 9 9M5 5a14 14 0 0 1 14 14"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="square"
+                        stroke-width="1.8"
+                      />
+                    </svg>
+                  </span>
                   <span class="source-row-title">
                     {{ source.title ?? source.slug }}
                   </span>
-                  <span
-                    class="source-row-status"
-                    :class="{
-                      active: source.periodicCrawlEnabled,
-                      idle: !source.periodicCrawlEnabled,
-                    }"
-                  >
-                    {{
-                      source.periodicCrawlEnabled
-                        ? `Auto ${source.periodicCrawlIntervalMinutes}m`
-                        : "Manual"
-                    }}
-                  </span>
-                </span>
-                <span class="source-row-meta-line">
-                  <span class="source-row-domain">
-                    {{ sourceDomainLabel(source.url) }}
-                  </span>
-                  <span class="source-row-meta"
-                    >{{ source.kind }} · {{ source.slug }}</span
-                  >
-                </span>
-                <span v-if="source.description" class="source-row-description">
-                  {{ source.description }}
                 </span>
               </button>
             </li>

--- a/frontend/src/source-api.ts
+++ b/frontend/src/source-api.ts
@@ -77,6 +77,7 @@ export type ApiError = {
 };
 
 export type SourceListItem = {
+  collectionId: string | null;
   collectorSettingsVersion: number | null;
   periodicCrawlEnabled: boolean;
   periodicCrawlIntervalMinutes: number;
@@ -86,10 +87,21 @@ export type SourceListItem = {
   kind: "feed" | "podcast" | "streaming";
   recordedAt: string | null;
   slug: string;
+  subscriptionId: string;
+  subscriptionPosition: number;
   title: string | null;
   url: string;
   urlHash: string;
   version: number | null;
+};
+
+export type SourceCollectionListItem = {
+  createdAt: string;
+  id: string;
+  parentCollectionId: string | null;
+  position: number;
+  sourceCount: number;
+  title: string;
 };
 
 export type PeriodicCrawlSettings = {
@@ -217,6 +229,10 @@ type ListSourcesResponse = {
   data: SourceListItem[];
 };
 
+type ListSourceCollectionsResponse = {
+  data: SourceCollectionListItem[];
+};
+
 type ListSourceCollectorPluginsResponse = {
   data: SourceCollectorPluginListItem[];
 };
@@ -291,6 +307,124 @@ export async function listSourceCollectorPlugins(): Promise<
   const payload = (await response.json()) as ListSourceCollectorPluginsResponse;
 
   return payload.data;
+}
+
+export async function listSourceCollections(): Promise<
+  SourceCollectionListItem[]
+> {
+  const response = await fetch("/api/v1/collections");
+
+  if (!response.ok) {
+    throw new Error("Failed to load source collections.");
+  }
+
+  const payload = (await response.json()) as ListSourceCollectionsResponse;
+
+  return payload.data;
+}
+
+export async function createSourceCollection(request: {
+  parentCollectionId?: string | null;
+  position: number;
+  title: string;
+}): Promise<SourceCollectionListItem> {
+  const response = await fetch("/api/v1/collections", {
+    body: JSON.stringify(request),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+  const payload = (await response.json()) as
+    | { data: SourceCollectionListItem }
+    | ErrorResponse;
+
+  if (!response.ok && "error" in payload) {
+    throw new Error(payload.error.message);
+  }
+
+  if ("data" in payload) {
+    return payload.data;
+  }
+
+  throw new Error("Source collection creation failed.");
+}
+
+export async function assignSourceToCollection(
+  sourceId: string,
+  request: {
+    collectionId?: string | null;
+    position: number;
+  },
+): Promise<SourceListItem> {
+  const response = await fetch(`/api/v1/sources/${sourceId}/collection`, {
+    body: JSON.stringify(request),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "PATCH",
+  });
+  const payload = (await response.json()) as
+    | { data: SourceListItem }
+    | ErrorResponse;
+
+  if (!response.ok && "error" in payload) {
+    throw new Error(payload.error.message);
+  }
+
+  if ("data" in payload) {
+    return payload.data;
+  }
+
+  throw new Error("Source collection assignment failed.");
+}
+
+export async function unsubscribeSource(subscriptionId: string): Promise<void> {
+  const response = await fetch(`/api/v1/subscriptions/${subscriptionId}`, {
+    method: "DELETE",
+  });
+
+  if (response.status === 204) {
+    return;
+  }
+
+  const payload = (await response.json()) as ErrorResponse;
+
+  if ("error" in payload) {
+    throw new Error(payload.error.message);
+  }
+
+  throw new Error("Source unsubscribe failed.");
+}
+
+export async function updateSourceCollection(
+  collectionId: string,
+  request: {
+    parentCollectionId?: string | null;
+    position: number;
+    title: string;
+  },
+): Promise<SourceCollectionListItem> {
+  const response = await fetch(`/api/v1/collections/${collectionId}`, {
+    body: JSON.stringify(request),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "PATCH",
+  });
+  const payload = (await response.json()) as
+    | { data: SourceCollectionListItem }
+    | ErrorResponse;
+
+  if (!response.ok && "error" in payload) {
+    throw new Error(payload.error.message);
+  }
+
+  if ("data" in payload) {
+    return payload.data;
+  }
+
+  throw new Error("Source collection update failed.");
 }
 
 export async function createSource(

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -212,11 +212,27 @@ h3 {
 }
 
 .browser-shell,
+.collection-dialog,
 .create-shell,
 .settings-shell {
   border: 1px solid var(--color-border-soft);
   border-radius: 0;
   background: var(--color-panel);
+}
+
+.collection-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgb(7 10 14 / 0.48);
+}
+
+.collection-dialog {
+  width: min(100%, 560px);
+  box-shadow: 0 24px 60px rgb(0 0 0 / 0.24);
 }
 
 .browser-shell {
@@ -387,36 +403,56 @@ h3 {
 
 .collection-group {
   display: grid;
-  gap: 8px;
+  gap: 0;
   border: 1px solid var(--color-border-soft);
   background: var(--color-panel);
 }
 
-.collection-header {
+.collection-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 12px 14px 10px;
-  border-bottom: 1px solid var(--color-border-soft);
-  background: var(--color-panel-muted);
+  padding-left: 14px;
 }
 
-.collection-actions {
+.collection-row-main {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+
+.collection-row + .collection-source-list {
+  border-top: 1px solid var(--color-border-soft);
+}
+
+.collection-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.collection-toggle-icon {
+  width: 14px;
+  height: 14px;
+  transition: transform 120ms ease;
+}
+
+.collection-toggle[aria-expanded="true"] .collection-toggle-icon {
+  transform: rotate(90deg);
 }
 
 .collection-source-list {
   padding: 0;
   flex: initial;
   overflow: visible;
-}
-
-.compact-empty-state {
-  padding: 14px;
-  min-height: auto;
 }
 
 .asset-list {
@@ -444,12 +480,37 @@ h3 {
 }
 
 .source-row {
-  display: grid;
-  gap: 5px;
-  padding: 11px 16px 11px 18px;
+  display: block;
+  padding: 10px 16px 10px 18px;
   border-left: 3px solid transparent;
   background: transparent;
   text-align: left;
+}
+
+.source-row-child {
+  padding-left: 42px;
+}
+
+.source-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.source-row-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex: none;
+  color: var(--color-text-muted);
+}
+
+.source-row-icon-svg {
+  width: 14px;
+  height: 14px;
 }
 
 .source-row:hover,
@@ -463,7 +524,6 @@ h3 {
   background: var(--color-selected-bg);
 }
 
-.source-row-head,
 .content-row-head {
   display: flex;
   align-items: flex-start;
@@ -474,11 +534,14 @@ h3 {
 .source-row-title,
 .content-row-title {
   min-width: 0;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: 700;
   line-height: 1.35;
 }
 
-.source-row-status,
 .content-row-status,
 .source-row-domain {
   display: inline-flex;
@@ -491,17 +554,6 @@ h3 {
   font-weight: 700;
 }
 
-.source-row-status.active {
-  color: var(--status-active-text);
-  background: var(--status-active-bg);
-}
-
-.source-row-status.idle {
-  color: var(--status-idle-text);
-  background: var(--status-idle-bg);
-}
-
-.source-row-meta-line,
 .content-row-meta {
   display: flex;
   flex-wrap: wrap;
@@ -509,28 +561,13 @@ h3 {
   align-items: center;
 }
 
-.source-row-meta,
 .content-row-meta,
 .content-row-summary,
 .detail-meta,
 .asset-meta,
-.detail-count,
-.source-row-description {
+.detail-count {
   color: var(--color-text-soft);
   font-size: 0.82rem;
-}
-
-.source-row-domain {
-  background: var(--color-chip-bg);
-  color: var(--color-chip-text);
-}
-
-.source-row-description {
-  display: -webkit-box;
-  overflow: hidden;
-  line-height: 1.45;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
 }
 
 .content-row {
@@ -803,6 +840,7 @@ h3 {
   background: var(--color-feedback-error-bg);
 }
 
+.collection-dialog,
 .create-shell,
 .settings-shell {
   padding: 18px;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -378,6 +378,47 @@ h3 {
   overflow: auto;
 }
 
+.collection-browser {
+  display: grid;
+  gap: 10px;
+  padding: 10px;
+  overflow: auto;
+}
+
+.collection-group {
+  display: grid;
+  gap: 8px;
+  border: 1px solid var(--color-border-soft);
+  background: var(--color-panel);
+}
+
+.collection-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid var(--color-border-soft);
+  background: var(--color-panel-muted);
+}
+
+.collection-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.collection-source-list {
+  padding: 0;
+  flex: initial;
+  overflow: visible;
+}
+
+.compact-empty-state {
+  padding: 14px;
+  min-height: auto;
+}
+
 .asset-list {
   display: grid;
   gap: 10px;

--- a/frontend/test/source-api.test.ts
+++ b/frontend/test/source-api.test.ts
@@ -1,13 +1,348 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  assignSourceToCollection,
+  createSource,
+  createSourceCollection,
   discoverSources,
   getContentDetail,
   getSourceCollectorSettings,
   inspectSource,
+  listSourceCollections,
   listSourceCollectorPlugins,
+  listSources,
   previewSource,
+  unsubscribeSource,
 } from "../src/source-api.js";
+
+describe("listSources", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns source list data on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  collectorSettingsVersion: 1,
+                  createdAt: "2026-06-02T00:00:00.000Z",
+                  description: "Weekly notes",
+                  id: "source-1",
+                  kind: "podcast",
+                  periodicCrawlEnabled: true,
+                  periodicCrawlIntervalMinutes: 60,
+                  recordedAt: "2026-06-02T00:00:00.000Z",
+                  slug: "example-feed",
+                  title: "Example Feed",
+                  collectionId: null,
+                  subscriptionId: "subscription-1",
+                  subscriptionPosition: 0,
+                  url: "https://example.com/feed.xml",
+                  urlHash: "hash-1",
+                  version: 1,
+                },
+              ],
+            }),
+            {
+              headers: {
+                "content-type": "application/json",
+              },
+              status: 200,
+            },
+          ),
+        ),
+      ),
+    );
+
+    await expect(listSources()).resolves.toEqual([
+      {
+        collectorSettingsVersion: 1,
+        createdAt: "2026-06-02T00:00:00.000Z",
+        description: "Weekly notes",
+        id: "source-1",
+        kind: "podcast",
+        periodicCrawlEnabled: true,
+        periodicCrawlIntervalMinutes: 60,
+        recordedAt: "2026-06-02T00:00:00.000Z",
+        slug: "example-feed",
+        title: "Example Feed",
+        collectionId: null,
+        subscriptionId: "subscription-1",
+        subscriptionPosition: 0,
+        url: "https://example.com/feed.xml",
+        urlHash: "hash-1",
+        version: 1,
+      },
+    ]);
+  });
+});
+
+describe("listSourceCollections", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns collection list data on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  createdAt: "2026-06-02T00:00:00.000Z",
+                  id: "collection-1",
+                  parentCollectionId: null,
+                  position: 0,
+                  sourceCount: 1,
+                  title: "Work",
+                },
+              ],
+            }),
+            {
+              headers: {
+                "content-type": "application/json",
+              },
+              status: 200,
+            },
+          ),
+        ),
+      ),
+    );
+
+    await expect(listSourceCollections()).resolves.toEqual([
+      {
+        createdAt: "2026-06-02T00:00:00.000Z",
+        id: "collection-1",
+        parentCollectionId: null,
+        position: 0,
+        sourceCount: 1,
+        title: "Work",
+      },
+    ]);
+  });
+});
+
+describe("createSource", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns created source data on success", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              collectorSettingsVersion: 1,
+              createdAt: "2026-06-02T00:00:00.000Z",
+              description: "Weekly notes",
+              id: "source-1",
+              kind: "podcast",
+              periodicCrawlEnabled: true,
+              periodicCrawlIntervalMinutes: 60,
+              recordedAt: "2026-06-02T00:00:00.000Z",
+              slug: "example-feed",
+              title: "Example Feed",
+              collectionId: null,
+              subscriptionId: "subscription-1",
+              subscriptionPosition: 0,
+              url: "https://example.com/feed.xml",
+              urlHash: "hash-1",
+              version: 1,
+            },
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+            },
+            status: 201,
+          },
+        ),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      createSource({
+        description: "Weekly notes",
+        sourceSlug: "example-feed",
+        title: "Example Feed",
+        url: "https://example.com/feed.xml",
+      }),
+    ).resolves.toEqual({
+      collectorSettingsVersion: 1,
+      createdAt: "2026-06-02T00:00:00.000Z",
+      description: "Weekly notes",
+      id: "source-1",
+      kind: "podcast",
+      periodicCrawlEnabled: true,
+      periodicCrawlIntervalMinutes: 60,
+      recordedAt: "2026-06-02T00:00:00.000Z",
+      slug: "example-feed",
+      title: "Example Feed",
+      collectionId: null,
+      subscriptionId: "subscription-1",
+      subscriptionPosition: 0,
+      url: "https://example.com/feed.xml",
+      urlHash: "hash-1",
+      version: 1,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/sources",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+});
+
+describe("createSourceCollection", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns created collection data on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: {
+                createdAt: "2026-06-02T00:00:00.000Z",
+                id: "collection-1",
+                parentCollectionId: null,
+                position: 0,
+                sourceCount: 0,
+                title: "Work",
+              },
+            }),
+            {
+              headers: {
+                "content-type": "application/json",
+              },
+              status: 201,
+            },
+          ),
+        ),
+      ),
+    );
+
+    await expect(
+      createSourceCollection({
+        position: 0,
+        title: "Work",
+      }),
+    ).resolves.toEqual({
+      createdAt: "2026-06-02T00:00:00.000Z",
+      id: "collection-1",
+      parentCollectionId: null,
+      position: 0,
+      sourceCount: 0,
+      title: "Work",
+    });
+  });
+});
+
+describe("assignSourceToCollection", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns updated source data on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: {
+                collectorSettingsVersion: 1,
+                createdAt: "2026-06-02T00:00:00.000Z",
+                description: "Weekly notes",
+                id: "source-1",
+                kind: "podcast",
+                periodicCrawlEnabled: true,
+                periodicCrawlIntervalMinutes: 60,
+                recordedAt: "2026-06-02T00:00:00.000Z",
+                slug: "example-feed",
+                title: "Example Feed",
+                collectionId: "collection-1",
+                subscriptionId: "subscription-1",
+                subscriptionPosition: 2,
+                url: "https://example.com/feed.xml",
+                urlHash: "hash-1",
+                version: 1,
+              },
+            }),
+            {
+              headers: {
+                "content-type": "application/json",
+              },
+              status: 200,
+            },
+          ),
+        ),
+      ),
+    );
+
+    await expect(
+      assignSourceToCollection("source-1", {
+        collectionId: "collection-1",
+        position: 2,
+      }),
+    ).resolves.toEqual({
+      collectorSettingsVersion: 1,
+      createdAt: "2026-06-02T00:00:00.000Z",
+      description: "Weekly notes",
+      id: "source-1",
+      kind: "podcast",
+      periodicCrawlEnabled: true,
+      periodicCrawlIntervalMinutes: 60,
+      recordedAt: "2026-06-02T00:00:00.000Z",
+      slug: "example-feed",
+      title: "Example Feed",
+      collectionId: "collection-1",
+      subscriptionId: "subscription-1",
+      subscriptionPosition: 2,
+      url: "https://example.com/feed.xml",
+      urlHash: "hash-1",
+      version: 1,
+    });
+  });
+});
+
+describe("unsubscribeSource", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns on 204 response", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(null, {
+          status: 204,
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(unsubscribeSource("subscription-1")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/subscriptions/subscription-1",
+      expect.objectContaining({
+        method: "DELETE",
+      }),
+    );
+  });
+});
 
 describe("inspectSource", () => {
   afterEach(() => {

--- a/scripts/run-data-migration.sh
+++ b/scripts/run-data-migration.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: sh scripts/run-data-migration.sh <migration-sql-path>" >&2
+  exit 1
+fi
+
+root_dir=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+migration_path="$1"
+
+case "$migration_path" in
+  /*) ;;
+  *) migration_path="$root_dir/$migration_path" ;;
+esac
+
+if [ ! -f "$migration_path" ]; then
+  echo "migration file not found: $migration_path" >&2
+  exit 1
+fi
+
+compose_file="${COMPOSE_FILE_PATH:-compose.yaml}"
+postgres_service="${POSTGRES_SERVICE_NAME:-postgres}"
+db_name="${DB_NAME:-geshi}"
+db_user="${DB_USER:-geshi}"
+
+docker compose -f "$compose_file" exec -T "$postgres_service" \
+  psql -v ON_ERROR_STOP=1 -U "$db_user" -d "$db_name" \
+  < "$migration_path"

--- a/test/cases/source-observe.spec.ts
+++ b/test/cases/source-observe.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 const sourceFeedUrl =
@@ -35,7 +35,9 @@ test("detects multiple source candidates from a discovery page and registers the
   await expect(podcastCandidate.getByText("Discovery Episode 1")).toBeVisible();
   await duplicatePodcastCandidate.getByRole("checkbox").uncheck();
 
-  await page.getByRole("button", { name: "Register selected sources" }).click();
+  await page
+    .getByRole("button", { name: "Subscribe selected sources" })
+    .click();
 
   await expect(
     page.getByRole("heading", { level: 2, name: "Add source" }),
@@ -81,7 +83,9 @@ test("registers a source from direct feed discovery and observes contents", asyn
   await expect(selectedCandidate).toBeVisible();
   await expect(selectedCandidate.getByText("Episode 1")).toBeVisible();
   await duplicateCandidate.getByRole("checkbox").uncheck();
-  await page.getByRole("button", { name: "Register selected sources" }).click();
+  await page
+    .getByRole("button", { name: "Subscribe selected sources" })
+    .click();
 
   await expect(
     page.getByRole("heading", { level: 2, name: "Geshi E2E Feed" }),
@@ -124,7 +128,9 @@ test("opens entry detail and exposes playable audio", async ({
   await candidateRow(page, "Geshi E2E Feed", "rss / feed")
     .getByRole("checkbox")
     .uncheck();
-  await page.getByRole("button", { name: "Register selected sources" }).click();
+  await page
+    .getByRole("button", { name: "Subscribe selected sources" })
+    .click();
 
   await expect(
     page.getByRole("heading", { level: 2, name: "Geshi E2E Feed" }),
@@ -236,10 +242,132 @@ test("opens entry detail and exposes playable audio", async ({
   ).toBeVisible();
 });
 
-async function openSourceRegistration(page: Page) {
-  await page.getByRole("button", { name: "Add source" }).click();
+test("organizes a subscription into a collection and back out", async ({
+  page,
+  request,
+}) => {
+  const collectionSourceFeedUrl = `${sourceFeedUrl}?collections=1`;
+
+  await page.goto("/");
+
+  await openSourceRegistration(page);
+  await detectSources(page, collectionSourceFeedUrl);
+  await candidateRow(page, "Geshi E2E Feed", "rss / feed")
+    .getByRole("checkbox")
+    .uncheck();
+  await page
+    .getByRole("button", { name: "Subscribe selected sources" })
+    .click();
+
+  const sourceSlug = await waitForSourceSlugByUrl(
+    request,
+    collectionSourceFeedUrl,
+  );
+
+  page.once("dialog", (dialog) => dialog.accept("Work"));
+  await page.getByRole("button", { name: "Add collection" }).click();
+
+  const uncategorizedGroup = collectionGroup(page, "Uncategorized");
+  const workGroup = collectionGroup(page, "Work");
+  const sourceRow = sourceRowButton(page, sourceSlug);
+
+  await expect(workGroup).toBeVisible();
   await expect(
-    page.getByRole("heading", { level: 2, name: "Add source" }),
+    uncategorizedGroup.getByRole("button", {
+      name: new RegExp(sourceSlug, "u"),
+    }),
+  ).toBeVisible();
+
+  await dragSourceRowToTarget(
+    sourceRow,
+    workGroup.locator(".collection-header"),
+  );
+
+  await expect(
+    workGroup.getByRole("button", { name: new RegExp(sourceSlug, "u") }),
+  ).toBeVisible();
+  await expect(
+    uncategorizedGroup.getByRole("button", {
+      name: new RegExp(sourceSlug, "u"),
+    }),
+  ).toHaveCount(0);
+
+  await page.reload();
+
+  await expect(
+    collectionGroup(page, "Work").getByRole("button", {
+      name: new RegExp(sourceSlug, "u"),
+    }),
+  ).toBeVisible();
+
+  const movedSourcesResponse = await request.get("/api/v1/sources");
+  const movedSourcesPayload = (await movedSourcesResponse.json()) as {
+    data: Array<{
+      collectionId: string | null;
+      title: string | null;
+      url: string;
+    }>;
+  };
+  const movedSource = movedSourcesPayload.data.find(
+    (source) => source.url === collectionSourceFeedUrl,
+  );
+
+  expect(movedSource?.collectionId).not.toBeNull();
+
+  await collectionGroup(page, "Work")
+    .getByRole("button", { name: new RegExp(sourceSlug, "u") })
+    .evaluate((element) => {
+      (element as HTMLElement).scrollIntoView({
+        block: "center",
+      });
+    });
+  await dragSourceRowToTarget(
+    collectionGroup(page, "Work").getByRole("button", {
+      name: new RegExp(sourceSlug, "u"),
+    }),
+    collectionGroup(page, "Uncategorized").locator(".collection-header"),
+  );
+
+  await expect(
+    collectionGroup(page, "Uncategorized").getByRole("button", {
+      name: new RegExp(sourceSlug, "u"),
+    }),
+  ).toBeVisible();
+  await expect(
+    collectionGroup(page, "Work").getByRole("button", {
+      name: new RegExp(sourceSlug, "u"),
+    }),
+  ).toHaveCount(0);
+
+  await page.reload();
+
+  await expect(
+    collectionGroup(page, "Uncategorized").getByRole("button", {
+      name: new RegExp(sourceSlug, "u"),
+    }),
+  ).toBeVisible();
+
+  const restoredSourcesResponse = await request.get("/api/v1/sources");
+  const restoredSourcesPayload = (await restoredSourcesResponse.json()) as {
+    data: Array<{
+      collectionId: string | null;
+      title: string | null;
+      url: string;
+    }>;
+  };
+  const restoredSource = restoredSourcesPayload.data.find(
+    (source) => source.url === collectionSourceFeedUrl,
+  );
+
+  expect(restoredSource?.collectionId).toBeNull();
+});
+
+async function openSourceRegistration(page: Page) {
+  await page.getByRole("button", { name: "Add source" }).evaluate((element) => {
+    (element as HTMLButtonElement).click();
+  });
+  await expect(
+    page.getByRole("heading", { level: 2, name: "Add subscription" }),
   ).toBeVisible();
 }
 
@@ -247,7 +375,10 @@ async function detectSources(page: Page, url: string) {
   await page.getByRole("textbox", { name: "Discovery URL" }).fill(url);
   await page.getByRole("button", { name: "Detect sources" }).click();
   await expect(
-    page.getByRole("heading", { level: 3, name: "Select sources to register" }),
+    page.getByRole("heading", {
+      level: 3,
+      name: "Select sources to subscribe",
+    }),
   ).toBeVisible();
 }
 
@@ -256,4 +387,68 @@ function candidateRow(page: Page, title: string, meta: string) {
     has: page.locator(".candidate-option-title", { hasText: title }),
     hasText: meta,
   });
+}
+
+function collectionGroup(page: Page, title: string) {
+  return page.locator(".collection-group").filter({
+    has: page.getByRole("heading", { level: 3, name: title }),
+  });
+}
+
+function sourceRowButton(page: Page, title: string) {
+  return page.getByRole("button", { name: new RegExp(title, "u") }).first();
+}
+
+async function waitForSourceSlugByUrl(
+  request: APIRequestContext,
+  url: string,
+): Promise<string> {
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get("/api/v1/sources");
+        const payload = (await response.json()) as {
+          data: Array<{
+            slug: string;
+            url: string;
+          }>;
+        };
+
+        return payload.data.find((source) => source.url === url)?.slug ?? null;
+      },
+      {
+        timeout: 30_000,
+      },
+    )
+    .not.toBeNull();
+
+  const response = await request.get("/api/v1/sources");
+  const payload = (await response.json()) as {
+    data: Array<{
+      slug: string;
+      url: string;
+    }>;
+  };
+  const source = payload.data.find((item) => item.url === url);
+
+  if (source === undefined) {
+    throw new Error(`Source not found for URL: ${url}`);
+  }
+
+  return source.slug;
+}
+
+async function dragSourceRowToTarget(
+  source: Locator,
+  target: Locator,
+): Promise<void> {
+  const dataTransfer = await source
+    .page()
+    .evaluateHandle(() => new DataTransfer());
+
+  await source.dispatchEvent("dragstart", { dataTransfer });
+  await target.dispatchEvent("dragenter", { dataTransfer });
+  await target.dispatchEvent("dragover", { dataTransfer });
+  await target.dispatchEvent("drop", { dataTransfer });
+  await source.dispatchEvent("dragend", { dataTransfer });
 }


### PR DESCRIPTION
## Summary
- replace collection prompt flows with an in-app collection dialog
- move browse display mode and theme controls into settings
- simplify the source tree UI and align folder/source rows for explorer-style browsing
- add an `All` row and fix keyboard navigation after mouse selection

## Verification
- `npm run precommit`

## Notes
- source rows now use a compact single-line presentation
- collection rows are reduced to tree-style structure with drag-and-drop organization