### PR TITLE
Fix stale observe recovery queue id comparison

### DIFF
--- a/backend/src/db/job-repository.ts
+++ b/backend/src/db/job-repository.ts
@@ -309,7 +309,7 @@ export class JobRepository {
           sql<boolean>`exists (
             select 1
             from pgboss.job as queue_job
-            where queue_job.id = jobs.queue_job_id
+            where queue_job.id::text = jobs.queue_job_id
               and queue_job.state in ('created', 'retry', 'active')
           )`.as("queue_job_is_active"),
           sql<string | null>`jobs.payload -> 'source' ->> 'id'`.as("source_id"),
@@ -388,7 +388,7 @@ export class JobRepository {
             sql<boolean>`not exists (
               select 1
               from pgboss.job as queue_job
-              where queue_job.id = jobs.queue_job_id
+              where queue_job.id::text = jobs.queue_job_id
                 and queue_job.state in ('created', 'retry', 'active')
             )`,
             "=",


### PR DESCRIPTION
## What

Cast PgBoss queue job ids to text when ADR-0072 stale observe recovery compares `pgboss.job.id` with `jobs.queue_job_id`.

## Why

PgBoss stores `job.id` as `uuid`, while geshi stores `jobs.queue_job_id` as text. The recovery query failed at runtime with `operator does not exist: uuid = text`, so the stale stanica observe-source job was not recovered and periodic crawl could not schedule a fresh observe.

## Related

- ADR-0072: stale observe-source job detection and recovery
- #721

## Additional Notes

Runtime verification on the local DB confirmed that the stale stanica observe-source job was marked failed by periodic-crawl, a new observe-source job succeeded with `observedContentCount=6`, and related acquire-content jobs completed. Existing stale acquire-content jobs remain outside ADR-0072 scope.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly

Checks run:

- `npm run -s test -- --run backend/test/workers/periodic-crawl.test.ts`
- `npm run typecheck`
- `npm run lint`