### PR TITLE
[codex] Add Atom support to built-in feed collectors

### DIFF
--- a/backend/src/plugins/collector/atom-feed.ts
+++ b/backend/src/plugins/collector/atom-feed.ts
@@ -1,0 +1,148 @@
+import { XMLParser } from "fast-xml-parser";
+
+type AtomFeed = {
+  feed?: {
+    entry?: AtomEntry | AtomEntry[];
+    subtitle?: AtomTextNode;
+    title?: AtomTextNode;
+  };
+};
+
+type AtomEntry = {
+  content?: AtomTextNode;
+  id?: AtomTextNode;
+  link?: AtomLinkNode | AtomLinkNode[];
+  published?: AtomTextNode;
+  summary?: AtomTextNode;
+  title?: AtomTextNode;
+  updated?: AtomTextNode;
+};
+
+type AtomLinkNode = {
+  "@_href"?: string;
+  "@_rel"?: string;
+  "@_type"?: string;
+};
+
+type AtomTextNode = string | { "#text"?: string };
+
+export type NormalizedFeedEnclosure = {
+  "@_type"?: string;
+  "@_url"?: string;
+};
+
+export type NormalizedFeedItem = {
+  description?: string;
+  enclosure?: NormalizedFeedEnclosure;
+  guid?: string;
+  link?: string;
+  pubDate?: string;
+  title?: string;
+};
+
+export type ParsedAtomFeed = {
+  items: NormalizedFeedItem[];
+  metadata: {
+    description: string | null;
+    title: string | null;
+  };
+};
+
+const parser = new XMLParser({
+  attributeNamePrefix: "@_",
+  ignoreAttributes: false,
+  parseTagValue: false,
+  trimValues: true,
+});
+
+export function parseAtomFeed(
+  value: string,
+  options: {
+    requireAudioEnclosure?: boolean;
+  } = {},
+): ParsedAtomFeed | null {
+  const parsedFeed = parser.parse(value) as AtomFeed;
+  const feed = parsedFeed.feed;
+
+  if (feed === undefined) {
+    return null;
+  }
+
+  const items = toArray(feed.entry).map(normalizeAtomEntry);
+
+  if (
+    options.requireAudioEnclosure === true &&
+    !items.some((item) => item.enclosure?.["@_type"]?.startsWith("audio/"))
+  ) {
+    return null;
+  }
+
+  return {
+    items,
+    metadata: {
+      description: normalizeTextNode(feed.subtitle),
+      title: normalizeTextNode(feed.title),
+    },
+  };
+}
+
+function normalizeAtomEntry(entry: AtomEntry): NormalizedFeedItem {
+  const links = toArray(entry.link);
+  const pageLink = selectPageLink(links);
+  const enclosureLink = selectEnclosureLink(links);
+
+  return {
+    description:
+      normalizeTextNode(entry.summary) ??
+      normalizeTextNode(entry.content) ??
+      undefined,
+    enclosure:
+      enclosureLink === undefined
+        ? undefined
+        : {
+            "@_type": normalizeString(enclosureLink["@_type"]) ?? undefined,
+            "@_url": normalizeString(enclosureLink["@_href"]) ?? undefined,
+          },
+    guid: normalizeTextNode(entry.id) ?? undefined,
+    link: normalizeString(pageLink?.["@_href"]) ?? undefined,
+    pubDate:
+      normalizeTextNode(entry.published) ??
+      normalizeTextNode(entry.updated) ??
+      undefined,
+    title: normalizeTextNode(entry.title) ?? undefined,
+  };
+}
+
+function selectPageLink(links: AtomLinkNode[]): AtomLinkNode | undefined {
+  return links.find((link) => {
+    const rel = normalizeString(link["@_rel"]);
+
+    return rel === null || rel === "alternate";
+  });
+}
+
+function selectEnclosureLink(links: AtomLinkNode[]): AtomLinkNode | undefined {
+  return links.find((link) => normalizeString(link["@_rel"]) === "enclosure");
+}
+
+function normalizeTextNode(value: AtomTextNode | undefined): string | null {
+  if (typeof value === "string") {
+    return normalizeString(value);
+  }
+
+  return normalizeString(value?.["#text"]);
+}
+
+function normalizeString(value: string | undefined): string | null {
+  const normalizedValue = value?.trim();
+
+  return normalizedValue ? normalizedValue : null;
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [value];
+}

--- a/backend/src/plugins/collector/podcast-rss/manifest.ts
+++ b/backend/src/plugins/collector/podcast-rss/manifest.ts
@@ -8,7 +8,7 @@ export const manifest: PluginManifest = {
       sourceKind: "podcast",
     },
   ],
-  description: "Collect podcast episodes from RSS feeds.",
+  description: "Collect podcast RSS and Atom feeds.",
   displayName: "Podcast RSS",
   pluginSlug: "podcast-rss",
 };

--- a/backend/src/plugins/collector/podcast-rss/plugin.ts
+++ b/backend/src/plugins/collector/podcast-rss/plugin.ts
@@ -22,6 +22,7 @@ import type {
   SourceMetadata,
 } from "../../types.js";
 import { WebClient } from "../../types.js";
+import { parseAtomFeed } from "../atom-feed.js";
 import { extractDiscoveredFeedUrls } from "../feed-discovery-html.js";
 import type {
   AcquiredAssetFingerprintInput,
@@ -142,7 +143,7 @@ export const plugin: SourceCollectorPlugin = {
     if (metadata === null) {
       throw new SourceCollectorInspectPluginError(
         "source_inspect_unrecognized",
-        "The given URL is not a supported RSS feed.",
+        "The given URL is not a supported RSS or Atom feed.",
       );
     }
 
@@ -532,17 +533,19 @@ function parsePodcastRssFeed(value: string): ParsedPodcastRssFeed | null {
   const parsedFeed = parser.parse(value) as RssFeed;
   const channel = parsedFeed.rss?.channel;
 
-  if (channel === undefined) {
-    return null;
+  if (channel !== undefined) {
+    return {
+      items: toArray(channel.item),
+      metadata: {
+        description: normalizeString(channel.description),
+        title: normalizeString(channel.title),
+      },
+    };
   }
 
-  return {
-    items: toArray(channel.item),
-    metadata: {
-      description: normalizeString(channel.description),
-      title: normalizeString(channel.title),
-    },
-  };
+  return parseAtomFeed(value, {
+    requireAudioEnclosure: true,
+  });
 }
 
 function toArray<T>(value: T | T[] | undefined): T[] {

--- a/backend/src/plugins/collector/rss/manifest.ts
+++ b/backend/src/plugins/collector/rss/manifest.ts
@@ -9,7 +9,7 @@ export const manifest: PluginManifest = {
     },
   ],
   description:
-    "Collect standard RSS feed entries as HTML pages and enclosures.",
+    "Collect RSS, RDF, and Atom feed entries as HTML pages and enclosures.",
   displayName: "RSS",
   pluginSlug: "rss",
 };

--- a/backend/src/plugins/collector/rss/plugin.ts
+++ b/backend/src/plugins/collector/rss/plugin.ts
@@ -22,6 +22,7 @@ import type {
   SourceMetadata,
 } from "../../types.js";
 import { WebClient } from "../../types.js";
+import { parseAtomFeed } from "../atom-feed.js";
 import { extractDiscoveredFeedUrls } from "../feed-discovery-html.js";
 import type {
   AcquiredAssetFingerprintInput,
@@ -149,7 +150,7 @@ export const plugin: SourceCollectorPlugin = {
     if (metadata === null) {
       throw new SourceCollectorInspectPluginError(
         "source_inspect_unrecognized",
-        "The given URL is not a supported RSS feed.",
+        "The given URL is not a supported RSS or Atom feed.",
       );
     }
 
@@ -557,17 +558,17 @@ function parseRssFeed(value: string): ParsedRssFeed | null {
   const parsedFeed = parser.parse(value) as RssFeed;
   const channel = parsedFeed.rss?.channel ?? parsedFeed["rdf:RDF"]?.channel;
 
-  if (channel === undefined) {
-    return null;
+  if (channel !== undefined) {
+    return {
+      items: toArray(channel.item ?? parsedFeed["rdf:RDF"]?.item),
+      metadata: {
+        description: normalizeString(channel.description),
+        title: normalizeString(channel.title),
+      },
+    };
   }
 
-  return {
-    items: toArray(channel.item ?? parsedFeed["rdf:RDF"]?.item),
-    metadata: {
-      description: normalizeString(channel.description),
-      title: normalizeString(channel.title),
-    },
-  };
+  return parseAtomFeed(value);
 }
 
 function toArray<T>(value: T | T[] | undefined): T[] {

--- a/backend/test/plugins/collector/podcast-rss/discover-preview.test.ts
+++ b/backend/test/plugins/collector/podcast-rss/discover-preview.test.ts
@@ -50,6 +50,82 @@ describe("podcastRssPlugin.discover", () => {
     });
     expect(result?.candidates[0]?.sourceSlug).toMatch(/^example-podcast/);
   });
+
+  it("returns a direct Atom podcast feed as a single candidate", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Example Podcast</title>
+              <subtitle>Weekly notes</subtitle>
+              <entry>
+                <id>tag:example.com,2026:episode-1</id>
+                <link href="https://example.com/episodes/1" />
+                <link
+                  rel="enclosure"
+                  type="audio/mpeg"
+                  href="https://cdn.example.com/audio/1.mp3"
+                />
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await podcastRssPlugin.discover?.(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        inputUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext() as never,
+    );
+
+    expect(result?.candidates).toHaveLength(1);
+    expect(result?.candidates[0]).toMatchObject({
+      description: "Weekly notes",
+      title: "Example Podcast",
+      url: "https://example.com/feed.xml",
+    });
+  });
+
+  it("does not accept non-podcast Atom feeds as podcast candidates", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Example Site Feed</title>
+              <subtitle>Notes</subtitle>
+              <entry>
+                <id>tag:example.com,2026:entry-1</id>
+                <link href="https://example.com/posts/1" />
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await podcastRssPlugin.discover?.(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        inputUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext() as never,
+    );
+
+    expect(result?.candidates).toEqual([]);
+  });
 });
 
 describe("podcastRssPlugin.preview", () => {
@@ -77,6 +153,46 @@ describe("podcastRssPlugin.preview", () => {
 
     expect(result?.items).toHaveLength(1);
     expect(result?.items[0]).toMatchObject({
+      title: "Episode 1",
+    });
+  });
+
+  it("returns preview data from Atom podcast entries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Example Podcast</title>
+              <entry>
+                <id>tag:example.com,2026:episode-1</id>
+                <title>Episode 1</title>
+                <summary>Summary 1</summary>
+                <updated>2024-01-01T00:00:00Z</updated>
+                <link rel="enclosure" type="audio/mpeg" href="https://cdn.example.com/1.mp3" />
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await podcastRssPlugin.preview?.(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        sourceUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext() as never,
+    );
+
+    expect(result?.items).toHaveLength(1);
+    expect(result?.items[0]).toMatchObject({
+      publishedAt: new Date("2024-01-01T00:00:00.000Z"),
+      summary: "Summary 1",
       title: "Episode 1",
     });
   });

--- a/backend/test/plugins/collector/podcast-rss/plugin.test.ts
+++ b/backend/test/plugins/collector/podcast-rss/plugin.test.ts
@@ -286,6 +286,68 @@ describe("podcastRssPlugin.observe", () => {
     expect(contents[0]?.publishedAt).toBeNull();
   });
 
+  it("builds podcast episodes from Atom entries with audio enclosures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Example Podcast</title>
+              <subtitle>Weekly notes</subtitle>
+              <entry>
+                <id>tag:example.com,2026:episode-1</id>
+                <title> Episode 1 </title>
+                <summary> Hello from Atom </summary>
+                <link href="https://example.com/episodes/1" />
+                <link
+                  rel="enclosure"
+                  type="audio/mpeg"
+                  href="https://cdn.example.com/audio/1.mp3"
+                />
+                <updated>2024-01-01T00:00:00Z</updated>
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await podcastRssPlugin.observe(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        sourceUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext(),
+    );
+    const contents = result.contents;
+
+    expect(contents).toHaveLength(1);
+    expect(contents[0]).toMatchObject({
+      externalId: "tag:example.com,2026:episode-1",
+      kind: "podcast-episode",
+      publishedAt: new Date("2024-01-01T00:00:00.000Z"),
+      status: "discovered",
+      summary: "Hello from Atom",
+      title: "Episode 1",
+    });
+    expect(contents[0]?.assets).toEqual([
+      expect.objectContaining({
+        kind: "html",
+        primary: true,
+        sourceUrl: "https://example.com/episodes/1",
+      }),
+      expect.objectContaining({
+        kind: "audio",
+        primary: false,
+        sourceUrl: "https://cdn.example.com/audio/1.mp3",
+      }),
+    ]);
+  });
+
   it("fails when RSS fetch returns a non-success status", async () => {
     vi.stubGlobal(
       "fetch",
@@ -343,6 +405,48 @@ describe("podcastRssPlugin.inspect", () => {
     });
   });
 
+  it("returns source metadata from Atom podcast feed metadata", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title> Example Podcast </title>
+              <subtitle> Weekly notes </subtitle>
+              <entry>
+                <id>tag:example.com,2026:episode-1</id>
+                <link href="https://example.com/episodes/1" />
+                <link
+                  rel="enclosure"
+                  type="audio/mpeg"
+                  href="https://cdn.example.com/audio/1.mp3"
+                />
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await podcastRssPlugin.inspect(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        sourceUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext(),
+    );
+
+    expect(result).toMatchObject({
+      description: "Weekly notes",
+      title: "Example Podcast",
+      url: "https://example.com/feed.xml",
+    });
+  });
+
   it("returns an unrecognized error for non-rss responses", async () => {
     vi.stubGlobal(
       "fetch",
@@ -362,7 +466,7 @@ describe("podcastRssPlugin.inspect", () => {
       ),
     ).rejects.toMatchObject({
       code: "source_inspect_unrecognized",
-      message: "The given URL is not a supported RSS feed.",
+      message: "The given URL is not a supported RSS or Atom feed.",
     });
   });
 });

--- a/backend/test/plugins/collector/rss/discover-preview.test.ts
+++ b/backend/test/plugins/collector/rss/discover-preview.test.ts
@@ -91,6 +91,44 @@ describe("rssPlugin.discover", () => {
     });
   });
 
+  it("returns a direct Atom feed as a single candidate", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Example Atom Feed</title>
+              <subtitle>Atom notes</subtitle>
+              <entry>
+                <id>tag:example.com,2026:entry-1</id>
+                <link href="https://example.com/posts/1" />
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await rssPlugin.discover?.(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        inputUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext() as never,
+    );
+
+    expect(result?.candidates).toHaveLength(1);
+    expect(result?.candidates[0]).toMatchObject({
+      description: "Atom notes",
+      title: "Example Atom Feed",
+      url: "https://example.com/feed.xml",
+    });
+  });
+
   it("discovers multiple feed candidates from an html feed listing page", async () => {
     vi.stubGlobal(
       "fetch",
@@ -212,6 +250,45 @@ describe("rssPlugin.preview", () => {
 
     expect(result?.items).toHaveLength(2);
     expect(result?.items[0]).toMatchObject({
+      title: "Entry 1",
+    });
+  });
+
+  it("returns preview data from Atom entries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Example Atom Feed</title>
+              <entry>
+                <id>tag:example.com,2026:entry-1</id>
+                <title>Entry 1</title>
+                <summary>Summary 1</summary>
+                <updated>2024-01-01T00:00:00Z</updated>
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await rssPlugin.preview?.(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        sourceUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext() as never,
+    );
+
+    expect(result?.items).toHaveLength(1);
+    expect(result?.items[0]).toMatchObject({
+      publishedAt: new Date("2024-01-01T00:00:00.000Z"),
+      summary: "Summary 1",
       title: "Entry 1",
     });
   });

--- a/backend/test/plugins/collector/rss/plugin.test.ts
+++ b/backend/test/plugins/collector/rss/plugin.test.ts
@@ -144,6 +144,67 @@ describe("rssPlugin.observe", () => {
       }),
     ]);
   });
+
+  it("builds feed entries from Atom entries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Example Atom Feed</title>
+              <subtitle>Atom notes</subtitle>
+              <entry>
+                <id>tag:example.com,2026:entry-1</id>
+                <title> Entry 1 </title>
+                <summary> Hello from Atom </summary>
+                <link href="https://example.com/posts/1" />
+                <link
+                  rel="enclosure"
+                  type="audio/mpeg"
+                  href="https://cdn.example.com/audio/1.mp3"
+                />
+                <updated>2024-01-01T00:00:00Z</updated>
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await rssPlugin.observe(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        sourceUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext(),
+    );
+
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0]).toMatchObject({
+      externalId: "tag:example.com,2026:entry-1",
+      kind: "feed-entry",
+      publishedAt: new Date("2024-01-01T00:00:00.000Z"),
+      status: "discovered",
+      summary: "Hello from Atom",
+      title: "Entry 1",
+    });
+    expect(result.contents[0]?.assets).toEqual([
+      expect.objectContaining({
+        kind: "html",
+        primary: true,
+        sourceUrl: "https://example.com/posts/1",
+      }),
+      expect.objectContaining({
+        kind: "audio",
+        primary: false,
+        sourceUrl: "https://cdn.example.com/audio/1.mp3",
+      }),
+    ]);
+  });
 });
 
 describe("rssPlugin.inspect", () => {
@@ -218,6 +279,43 @@ describe("rssPlugin.inspect", () => {
       description: "RDF notes",
       title: "Example RDF Feed",
       url: "https://example.com/feed.rdf",
+    });
+  });
+
+  it("returns source metadata from Atom feed fields", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            `<?xml version="1.0"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title> Example Atom Feed </title>
+              <subtitle> Atom notes </subtitle>
+              <entry>
+                <id>tag:example.com,2026:entry-1</id>
+                <link href="https://example.com/posts/1" />
+              </entry>
+            </feed>`,
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await rssPlugin.inspect(
+      {
+        abortSignal: new AbortController().signal,
+        config: {},
+        sourceUrl: "https://example.com/feed.xml",
+      },
+      createPluginContext(),
+    );
+
+    expect(result).toMatchObject({
+      description: "Atom notes",
+      title: "Example Atom Feed",
+      url: "https://example.com/feed.xml",
     });
   });
 });

--- a/docs/decisions/0075-atom-feed-support.md
+++ b/docs/decisions/0075-atom-feed-support.md
@@ -1,0 +1,96 @@
+# ADR-0075: built-in `rss` / `podcast-rss` plugin は Atom feed を扱えるようにする
+
+## ステータス
+
+決定
+
+## 範囲
+
+`geshi-sdk`, built-in `rss` / `podcast-rss` plugins, `api backend`, `web ui frontend`
+
+## コンテキスト
+
+- `geshi` の source 登録導線は，URL を起点に source 候補を検出し，preview を確認してから登録する
+- built-in `rss` / `podcast-rss` plugin は，feed 本体 URL の直接入力と，HTML の `link[rel=alternate]` からの候補発見の両方で使われる
+- 現在の feed discovery HTML 処理は `application/atom+xml` を feed 候補として認識する
+- 一方で，built-in `rss` / `podcast-rss` plugin の inspect / discover / observe は，実質的に RSS 2.0 と RDF を前提にしており，Atom の `<feed>` を parse できない
+- その結果，Atom feed を配信する site では，HTML から候補 URL を発見できても，その後の inspect が失敗し，登録候補として提示されない
+- built-in `podcast-rss` plugin の説明や test fixture には Atom への言及があるが，実装実態と一致していない
+- feed 提供側から見ると，RSS ではなく Atom を公開するのは一般的な選択肢であり，source 登録時点で除外される理由は薄い
+- Atom 対応を site ごとの特例 plugin で吸収すると，format 差分という共通論点を source 固有 plugin へ分散させることになり，built-in plugin の責務が不明瞭になる
+- 一方で，Atom と RSS は entry / item，`updated` / `pubDate`，`summary` / `description`，link 表現，enclosure 表現などの shape が異なるため，単純な文字列置換ではなく plugin 契約上の正規化方針が必要である
+
+## 決定
+
+built-in `rss` / `podcast-rss` plugin は，RSS / RDF に加えて Atom feed を first-class に扱う．
+
+Atom は別 plugin に分けず，既存の built-in feed collector の入力 format として吸収する．
+
+### built-in `rss` plugin
+
+- built-in `rss` plugin は，RSS 2.0 / RDF に加えて Atom feed を inspect / discover / preview / observe できるようにする
+- Atom feed を `rss` plugin が受理した場合は，`feed-entry` として既存 `rss` source と同じ domain vocabulary に正規化する
+- Atom entry からの metadata 変換規則は plugin 実装内で一貫して管理する
+- `rss` plugin の format 対応は source ごとの差し替えではなく，built-in 共通責務として扱う
+
+### built-in `podcast-rss` plugin
+
+- built-in `podcast-rss` plugin も Atom feed を inspect / discover / preview / observe できるようにする
+- ただし `podcast-rss` plugin が受理する Atom feed は，podcast source として必要な情報を満たすものに限る
+- `podcast-rss` plugin が Atom feed を受理した場合は，`podcast-episode` として既存の podcast domain vocabulary に正規化する
+- built-in `podcast-rss` plugin の説明と実装実態を一致させる
+
+### format 差分の扱い
+
+- Atom と RSS の違いは，plugin 内で共通の内部表現へ正規化してから preview / observe / fingerprint 計算へ渡す
+- format ごとの差分を frontend や route handler や service 層へ漏らさない
+- host は source URL が RSS か Atom かを意識せず，plugin の inspect / discover / preview / observe 結果だけを扱う
+- HTML 側の feed 発見ロジックは，Atom を候補として検出できる現行方針を維持する
+
+### source 登録と互換性
+
+- source 登録導線は，Atom feed を入力しても RSS feed と同様に候補検出と登録が成立することを目指す
+- 既存 RSS / RDF source の登録経路と observe 結果の挙動は壊さない
+- Atom 対応の追加によって既存 RSS / RDF source の fingerprint が変わらないようにする
+- Atom entry の fingerprint 規則は，RSS / RDF の既存規則を流用できる範囲では流用し，不足する field は Atom 側の同等概念へ写像する
+
+### 実装境界
+
+- Atom 対応は built-in `rss` / `podcast-rss` plugin と，必要最小限の shared parsing helper の範囲で扱う
+- Atom 対応のために source model や source 登録 API 契約を増やさない
+- plugin manifest や plugin list API は，Atom 対応を別 plugin として表現しない
+
+## 影響
+
+- Atom feed を配信する site を，既存の source 登録導線から扱えるようになる
+- feed discovery HTML と built-in collector の対応 format が一致し，「見つかるが登録できない」不整合が減る
+- built-in `rss` / `podcast-rss` plugin は，format 正規化の責務をより明示的に持つことになる
+- plugin test には，Atom feed を使った inspect / preview / observe / register 近傍の自動確認が必要になる
+- Atom podcast feed の受理条件を曖昧にすると `rss` と `podcast-rss` の候補重複や誤受理を招くため，実装時に判定条件を明示する必要がある
+
+## 代替案
+
+- Atom 用に built-in `atom` / `podcast-atom` plugin を新設する
+  - format 差分だけで plugin を分けると，利用者視点の選択肢が増える一方で，source 種別の意味と format の違いが混ざりやすいため採らない
+- Atom 対応は `rss` plugin だけに入れ，`podcast-rss` は RSS 2.0 のままにする
+  - `podcast-rss` の説明と実装の不一致が残り，Atom 形式の podcast source だけ登録失敗するため採らない
+- HTML discovery から `application/atom+xml` を除外する
+  - feed 発見側と collector 側の不一致は隠せても，Atom source 自体を扱えない制約が残るため採らない
+- source ごとの plugin で Atom 対応を個別吸収する
+  - format 差分という built-in 共通責務を site 固有 plugin へ分散させることになり，再利用性と説明可能性が下がるため採らない
+
+## 参考資料
+
+- [ADR-0011] ADR-0011: source クロールを plugin 境界で拡張可能にする
+- [ADR-0016] ADR-0016: source collector plugin は content と asset の fingerprint を返す
+- [ADR-0017] ADR-0017: api backend は fingerprint に基づいて content と asset の登録規則を適用する
+- [ADR-0066] ADR-0066: source collector plugin に source discovery と preview の登録前 API を追加する
+- [ADR-0067] ADR-0067: web ui frontend の source 登録フローを detect / preview / register に再構成する
+- [ADR-0074] ADR-0074: RSS source ごとの fingerprint と detail 抽出は plugin コードで切り替える
+
+[ADR-0011]: ./0011-source-crawl-plugin-responsibilities.md
+[ADR-0016]: ./0016-source-collector-content-and-asset-identity.md
+[ADR-0017]: ./0017-source-collector-upsert-based-on-identity.md
+[ADR-0066]: ./0066-source-registration-detect-and-preview-plugin-api.md
+[ADR-0067]: ./0067-web-ui-source-registration-detect-preview-flow.md
+[ADR-0074]: ./0074-rss-source-specific-strategies.md

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -74,3 +74,4 @@
 - [ADR-0071: 新規 source 候補を定期検知する worker を導入する](./0071-periodic-source-detection-worker.md)
 - [ADR-0072: 途中で停止した source crawl を検知して回復する](./0072-missing-queue-job-reconciliation.md)
 - [ADR-0073: entry 一覧 API は cursor ベースのページングを持つ](./0073-entry-list-pagination.md)
+- [ADR-0075: built-in `rss` / `podcast-rss` plugin は Atom feed を扱えるようにする](./0075-atom-feed-support.md)

--- a/frontend/test/source-api.test.ts
+++ b/frontend/test/source-api.test.ts
@@ -699,7 +699,7 @@ describe("inspectSource", () => {
             JSON.stringify({
               error: {
                 code: "source_inspect_unrecognized",
-                message: "The given URL is not a supported RSS feed.",
+                message: "The given URL is not a supported RSS or Atom feed.",
               },
             }),
             {
@@ -717,7 +717,7 @@ describe("inspectSource", () => {
       inspectSource({
         url: "https://example.com/feed.xml",
       }),
-    ).rejects.toThrow("The given URL is not a supported RSS feed.");
+    ).rejects.toThrow("The given URL is not a supported RSS or Atom feed.");
   });
 });
 


### PR DESCRIPTION
## What

- built-in `rss` / `podcast-rss` collector に Atom feed 対応を追加
- Atom 用の共通 parser を追加し，inspect / discover / preview / observe から使うように変更
- `podcast-rss` は audio enclosure を持つ Atom feed だけを受理するようにして，非 podcast Atom feed の誤検出を防止
- ADR-0075 を `決定` に更新し，ADR 一覧へ追加
- Atom 対応の plugin test と frontend inspect error expectation を追加

## Why

- 現状は HTML 側で `application/atom+xml` を feed 候補として発見できる一方，built-in collector 側は RSS / RDF しか parse できず，Atom feed が「見つかるが登録できない」状態になっていた
- `https://jnbk.app/feed.xml` のような Atom feed を既存の detect / preview / register 導線で扱える必要がある
- format 差分は built-in collector の責務として吸収し，site 固有 plugin へ逃がさない方が一貫している

## Related

- ADR-0075

## Additional Notes

- `podcast-rss` の manifest 説明を実装実態に合わせて `RSS and Atom` 対応へ更新
- `rss` collector も Atom entry を `feed-entry` に正規化する
- 実施した確認:
  - `npm run test -- backend/test/plugins/collector/rss/plugin.test.ts backend/test/plugins/collector/rss/discover-preview.test.ts backend/test/plugins/collector/podcast-rss/plugin.test.ts backend/test/plugins/collector/podcast-rss/discover-preview.test.ts frontend/test/source-api.test.ts`
  - `npm run typecheck`
  - `npx eslint backend/src/plugins/collector/atom-feed.ts backend/src/plugins/collector/rss/plugin.ts backend/src/plugins/collector/rss/manifest.ts backend/src/plugins/collector/podcast-rss/plugin.ts backend/src/plugins/collector/podcast-rss/manifest.ts backend/test/plugins/collector/rss/plugin.test.ts backend/test/plugins/collector/rss/discover-preview.test.ts backend/test/plugins/collector/podcast-rss/plugin.test.ts backend/test/plugins/collector/podcast-rss/discover-preview.test.ts frontend/test/source-api.test.ts`
  - `npx prettier --check backend/src/plugins/collector/atom-feed.ts backend/src/plugins/collector/rss/plugin.ts backend/src/plugins/collector/rss/manifest.ts backend/src/plugins/collector/podcast-rss/plugin.ts backend/src/plugins/collector/podcast-rss/manifest.ts backend/test/plugins/collector/rss/plugin.test.ts backend/test/plugins/collector/rss/discover-preview.test.ts backend/test/plugins/collector/podcast-rss/plugin.test.ts backend/test/plugins/collector/podcast-rss/discover-preview.test.ts frontend/test/source-api.test.ts docs/decisions/0075-atom-feed-support.md docs/decisions/README.md`

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly