### PR TITLE
:bug: Decode RSS HTML detail charset

### DIFF
--- a/backend/src/plugins/collector/rss/plugin.ts
+++ b/backend/src/plugins/collector/rss/plugin.ts
@@ -626,7 +626,10 @@ function extractCharsetFromHtmlMeta(body: Uint8Array): string | null {
 
     if (node.tagName === "meta") {
       const attributes = Object.fromEntries(
-        (node.attrs ?? []).map((attribute) => [attribute.name, attribute.value]),
+        (node.attrs ?? []).map((attribute) => [
+          attribute.name,
+          attribute.value,
+        ]),
       );
       const charset = normalizeEncodingLabel(attributes.charset ?? null);
 

--- a/backend/src/plugins/collector/rss/plugin.ts
+++ b/backend/src/plugins/collector/rss/plugin.ts
@@ -1,4 +1,5 @@
 import { XMLParser } from "fast-xml-parser";
+import { parse } from "parse5";
 
 import { createSourceSlug } from "../../../lib/source-slug.js";
 import type {
@@ -70,12 +71,25 @@ type RssEnclosure = {
   "@_url"?: string;
 };
 
+type Parse5Attribute = {
+  name: string;
+  value: string;
+};
+
+type Parse5Node = {
+  attrs?: Parse5Attribute[];
+  childNodes?: Parse5Node[];
+  tagName?: string;
+};
+
 const parser = new XMLParser({
   attributeNamePrefix: "@_",
   ignoreAttributes: false,
   parseTagValue: false,
   trimValues: true,
 });
+const TEXT_DECODER_FALLBACK_ENCODING = "utf-8";
+const META_CHARSET_SCAN_LENGTH = 2048;
 
 class SourceCollectorInspectPluginError extends Error {
   public readonly code: SourceCollectorInspectErrorCode;
@@ -223,7 +237,7 @@ export const plugin: SourceCollectorPlugin = {
       return Promise.resolve(null);
     }
 
-    const html = new TextDecoder().decode(input.asset.body);
+    const html = decodeHtmlDocument(input.asset.body, input.asset.mimeType);
 
     return Promise.resolve(extractHtmlDetailBody(html, input.asset.sourceUrl));
   },
@@ -550,6 +564,95 @@ function normalizeString(value: string | undefined): string | null {
 
 function normalizeContentType(value: string | null): string | null {
   const normalizedValue = value?.split(";")[0]?.trim();
+
+  return normalizedValue ? normalizedValue : null;
+}
+
+function decodeHtmlDocument(
+  body: Uint8Array,
+  contentType: string | null,
+): string {
+  const encoding = detectHtmlEncoding(body, contentType);
+
+  try {
+    return new TextDecoder(encoding).decode(body);
+  } catch {
+    return new TextDecoder(TEXT_DECODER_FALLBACK_ENCODING).decode(body);
+  }
+}
+
+function detectHtmlEncoding(
+  body: Uint8Array,
+  contentType: string | null,
+): string {
+  const headerCharset = extractCharsetFromContentType(contentType);
+
+  if (headerCharset !== null) {
+    return headerCharset;
+  }
+
+  const metaCharset = extractCharsetFromHtmlMeta(body);
+
+  if (metaCharset !== null) {
+    return metaCharset;
+  }
+
+  return TEXT_DECODER_FALLBACK_ENCODING;
+}
+
+function extractCharsetFromContentType(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const match = value.match(/charset\s*=\s*["']?([^;"'\s]+)/iu);
+
+  return normalizeEncodingLabel(match?.[1] ?? null);
+}
+
+function extractCharsetFromHtmlMeta(body: Uint8Array): string | null {
+  const scanBody = new TextDecoder("latin1").decode(
+    body.subarray(0, META_CHARSET_SCAN_LENGTH),
+  );
+  const document = parse(scanBody) as Parse5Node;
+  const nodes = [document];
+
+  while (nodes.length > 0) {
+    const node = nodes.shift();
+
+    if (node === undefined) {
+      continue;
+    }
+
+    if (node.tagName === "meta") {
+      const attributes = Object.fromEntries(
+        (node.attrs ?? []).map((attribute) => [attribute.name, attribute.value]),
+      );
+      const charset = normalizeEncodingLabel(attributes.charset ?? null);
+
+      if (charset !== null) {
+        return charset;
+      }
+
+      if (attributes["http-equiv"]?.toLowerCase() === "content-type") {
+        const contentCharset = extractCharsetFromContentType(
+          attributes.content ?? null,
+        );
+
+        if (contentCharset !== null) {
+          return contentCharset;
+        }
+      }
+    }
+
+    nodes.push(...(node.childNodes ?? []));
+  }
+
+  return null;
+}
+
+function normalizeEncodingLabel(value: string | null): string | null {
+  const normalizedValue = value?.trim().toLowerCase();
 
   return normalizedValue ? normalizedValue : null;
 }

--- a/backend/test/plugins/collector/rss/plugin.test.ts
+++ b/backend/test/plugins/collector/rss/plugin.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import { createNoopLogger } from "../../../../src/logger/index.js";
 import { rssPlugin } from "../../../../src/plugins/collector/rss/plugin.js";
 
+const KONNICHIWA_SHIFT_JIS = Uint8Array.from([
+  0x82, 0xb1, 0x82, 0xf1, 0x82, 0xc9, 0x82, 0xbf, 0x82, 0xcd,
+]);
+
 function createPluginContext() {
   return {
     getHost() {
@@ -341,6 +345,42 @@ describe("rssPlugin.extract", () => {
       format: "html",
     });
   });
+
+  it("extracts shift_jis html using meta charset", async () => {
+    const body = joinBytes([
+      asciiBytes(`
+        <html>
+          <head>
+            <meta charset="Shift_JIS" />
+          </head>
+          <body>
+            <main class="article-body">
+              <p>`),
+      KONNICHIWA_SHIFT_JIS,
+      asciiBytes(`</p>
+            </main>
+          </body>
+        </html>
+      `),
+    ]);
+
+    await expect(
+      rssPlugin.extract(
+        {
+          asset: {
+            body,
+            kind: "html",
+            mimeType: "text/html",
+            sourceUrl: "https://example.com/posts/1",
+          },
+        },
+        createPluginContext(),
+      ),
+    ).resolves.toEqual({
+      body: "<article><p>こんにちは</p></article>",
+      format: "html",
+    });
+  });
 });
 
 describe("rssPlugin.acquire", () => {
@@ -398,3 +438,20 @@ describe("rssPlugin.acquire", () => {
     ).toBe(true);
   });
 });
+
+function asciiBytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function joinBytes(chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## What

RSS collector の HTML detail 抽出で、HTML bytes を UTF-8 決め打ちせず charset に従って decode するようにしました。

- `Content-Type` の `charset` を見る
- HTML 先頭の `<meta charset>` / `http-equiv="content-type"` を見る
- charset が分からない場合や decode に失敗した場合は UTF-8 に fallback する
- Shift_JIS HTML の detail 抽出テストを追加する

## Why

`stat.go.jp` などの Shift_JIS HTML を RSS collector の detail 抽出で `new TextDecoder()` の既定 UTF-8 として読んでいたため、保存済み HTML bytes は正しくても生成される `detail_body` が文字化けしていました。

この PR は今後の detail 抽出経路を修正します。既存 DB データの書き換えは含めていません。

## Related

なし

## Additional Notes

Validation:

- `npm run test -- backend/test/plugins/collector/rss/plugin.test.ts`
- `npm run typecheck`

ローカル作業ツリーには、この PR に含めていない `.gitignore` の `.worktrees/` 追加が未コミットで残っています。

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly